### PR TITLE
Update WNL sign convention and fix bug in normal form coeffs

### DIFF
--- a/basecompute.md
+++ b/basecompute.md
@@ -86,9 +86,9 @@ else if(fileext == "hoho") {
   real[int] sym1(sym.n), sym2(sym.n);
   real omega1, omega2;
   complex[string] alpha1, alpha2;
-  complex beta1, beta2, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23;
+  complex beta1, beta2, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23;
   complex[int] q1m, q1ma, q2m, q2ma;
-  ub[] = loadhoho(fileroot, meshin, q1m, q1ma, q2m, q2ma, sym1, sym2, omega1, omega2, alpha1, alpha2, beta1, beta2, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23);
+  ub[] = loadhoho(fileroot, meshin, q1m, q1ma, q2m, q2ma, sym1, sym2, omega1, omega2, alpha1, alpha2, beta1, beta2, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23);
 }
 else if(fileext == "tdns") {
   real time;

--- a/basecontinue.md
+++ b/basecontinue.md
@@ -100,9 +100,9 @@ if(count == 0) {
     real[int] sym1(sym.n), sym2(sym.n);
     real omega1, omega2;
     complex[string] alpha1, alpha2;
-    complex beta1, beta2, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23;
+    complex beta1, beta2, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23;
     complex[int] q1m, q1ma, q2m, q2ma;
-    ub[] = loadhoho(fileroot, meshin, q1m, q1ma, q2m, q2ma, sym1, sym2, omega1, omega2, alpha1, alpha2, beta1, beta2, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23);
+    ub[] = loadhoho(fileroot, meshin, q1m, q1ma, q2m, q2ma, sym1, sym2, omega1, omega2, alpha1, alpha2, beta1, beta2, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23);
   }
   else if (filein == "") {
     setparams(paramnames,params);

--- a/basedeflate.md
+++ b/basedeflate.md
@@ -92,9 +92,9 @@ else if(fileext == "hoho") {
   real[int] sym1(sym.n), sym2(sym.n);
   real omega1, omega2;
   complex[string] alpha1, alpha2;
-  complex beta1, beta2, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23;
+  complex beta1, beta2, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23;
   complex[int] q1m, q1ma, q2m, q2ma;
-  ub[] = loadhoho(fileroot, meshin, q1m, q1ma, q2m, q2ma, sym1, sym2, omega1, omega2, alpha1, alpha2, beta1, beta2, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23);
+  ub[] = loadhoho(fileroot, meshin, q1m, q1ma, q2m, q2ma, sym1, sym2, omega1, omega2, alpha1, alpha2, beta1, beta2, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23);
 }
 else if(fileext == "tdns") {
   real time;

--- a/examples/FK_problem/README.md
+++ b/examples/FK_problem/README.md
@@ -33,21 +33,15 @@ FreeFem++-mpi -v 0 examples/FK_problem/cylinder_vessel.md -mo $workdir/cylinder_
 ```
 
 ## Perform parallel computations using `ff-bifbox`
-### Zeroth order
-1. Compute base states on the created meshes at $Da=0$ from default guess
-```sh
-ff-mpirun -np $nproc basecompute.md -v 0 -dir $workdir -mi cylinder_vessel.msh -fo cylinder_vessel -Da 0 -tgv -2
-```
-
-2. Continue base state along the parameter $Da$ 
+### Continue base state along the parameter $Da$ from trivial solution
 
 ```sh
-ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi cylinder_vessel.base -fo cylinder_vessel -param Da -h0 1 -scount 2 -maxcount 25 -tgv -2 -amax 10 -dmax 0.5 -kmax 1 -contorder 1
+ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -mi cylinder_vessel.msh -fo cylinder_vessel -param Da -h0 1 -scount 2 -maxcount 25 -tgv -2 -amax 10 -dmax 0.5 -kmax 1 -contorder 1
 ```
 This step computes the steady-state bifurcation diagram.
 
 
-# Compute fold bifurcation 
+### Compute fold bifurcation 
 ```sh
 cd "$workdir" && declare -a foldguesslist=(cylinder_vessel_*specialpt.base) && cd -
 for guess in "${foldguesslist[@]}"; do
@@ -55,17 +49,16 @@ ff-mpirun -np $nproc foldcompute.md -v 0 -dir $workdir -fi "$guess" -fo cylinder
 done
 ````
 Example output:
- alpha[Da] = -2.6252,
- beta = -0.91967,
- Da = 2.00227,
- Tmax = 1.386.
+- `alpha[Da] = -2.62803`
+- `beta = -0.91967`
+- `Da = 2.00011`
+- `Tmax = 1.38626`
 
-# Stability analysis 
-
+### Stability analysis 
 Compute eigenvalues along the branch:
 ```sh
 cd "$workdir" && declare -a baselist=(cylinder_vessel_*[0-9].base) && cd -
 for base in "${baselist[@]}"; do
-ff-mpirun -np $nproc modecompute.md -v 0 -dir $workdir -fi "$base" -fo "$base" -eps_target 1.0+0.0i -eps_gen_hermitian -tgv -2
+ff-mpirun -np $nproc modecompute.md -v 0 -dir $workdir -fi "$base" -so cylinder_vessel -eps_target 1.0+0.0i -eps_gen_hermitian -nev 3
 done
 ```

--- a/examples/FK_problem/README.md
+++ b/examples/FK_problem/README.md
@@ -55,8 +55,8 @@ ff-mpirun -np $nproc foldcompute.md -v 0 -dir $workdir -fi "$guess" -fo cylinder
 done
 ````
 Example output:
- alpha[Da] = 2.6252,
- beta = 0.91967,
+ alpha[Da] = -2.6252,
+ beta = -0.91967,
  Da = 2.00227,
  Tmax = 1.386.
 

--- a/examples/FK_problem/settings_FK.idp
+++ b/examples/FK_problem/settings_FK.idp
@@ -35,12 +35,11 @@ string ParaviewDataNamefc = "forcing_r forcing_i";
 int[int] ParaviewOrderc = [ParaviewOrder, ParaviewOrder];
 int[int] ParaviewOrderfc = [ParaviewOrderf, ParaviewOrderf];
 // Initial conditions (if no file)
-macro InitialConditions() 1// EOM
+macro InitialConditions() 0// EOM
 // Boundary labels 
 int BCnull = 0;
 int BCwall = 1;
 // Define solution monitors to extract: here maximum temperature in the domain
 macro getmonitors() {
-    real Tmax = ubg[].max;
-    monitors["Tmax"] = Tmax;
+    monitors["Tmax"] = ubg[].max;
 }// EOM

--- a/examples/douglas_2024/basecomputeaug.md
+++ b/examples/douglas_2024/basecomputeaug.md
@@ -81,9 +81,9 @@ else if(fileext == "hoho") {
   real[int] sym1(sym.n), sym2(sym.n);
   real omega1, omega2;
   complex[string] alpha1, alpha2;
-  complex beta1, beta2, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23;
+  complex beta1, beta2, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23;
   complex[int] q1m, q1ma, q2m, q2ma;
-  ub[] = loadhoho(fileroot, meshin, q1m, q1ma, q2m, q2ma, sym1, sym2, omega1, omega2, alpha1, alpha2, beta1, beta2, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23);
+  ub[] = loadhoho(fileroot, meshin, q1m, q1ma, q2m, q2ma, sym1, sym2, omega1, omega2, alpha1, alpha2, beta1, beta2, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23);
 }
 else if(fileext == "tdns") {
   real time;

--- a/examples/douglas_2024/modecomputeaug.md
+++ b/examples/douglas_2024/modecomputeaug.md
@@ -86,9 +86,9 @@ else if(fileext == "hoho") {
   real[int] sym1(sym.n), sym2(sym.n);
   real omega1, omega2;
   complex[string] alpha1, alpha2;
-  complex beta1, beta2, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23;
+  complex beta1, beta2, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23;
   complex[int] q1m, q1ma, q2m, q2ma;
-  ub[] = loadhoho(fileroot, meshin, q1m, q1ma, q2m, q2ma, sym1, sym2, omega1, omega2, alpha1, alpha2, beta1, beta2, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23);
+  ub[] = loadhoho(fileroot, meshin, q1m, q1ma, q2m, q2ma, sym1, sym2, omega1, omega2, alpha1, alpha2, beta1, beta2, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23);
 }
 else if(fileext == "tdns") {
   real time;

--- a/examples/douglas_etal_2021/README.md
+++ b/examples/douglas_etal_2021/README.md
@@ -67,7 +67,7 @@ ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi swirljet100.base -fo
 5. Compute backward and forward fold bifurcations from steady solution branch on base-adapted mesh
 ```sh
 cd $workdir && declare -a foldguesslist=(*specialpt.base) && cd -
-//note some shells may index from 1 and 2 instead of 0 and 1
+#note some shells may index from 1 and 2 instead of 0 and 1
 ff-mpirun -np $nproc foldcompute.md -v 0 -dir $workdir -fi ${foldguesslist[0]} -fo swirljet100_B -param S -mo swirljet100_B -adaptto b -thetamax 1 -nf 0
 ff-mpirun -np $nproc foldcompute.md -v 0 -dir $workdir -fi ${foldguesslist[1]} -fo swirljet100_F -param S -mo swirljet100_F -adaptto b -thetamax 1 -nf 0
 ```

--- a/examples/meliga_etal_2012/README.md
+++ b/examples/meliga_etal_2012/README.md
@@ -47,29 +47,40 @@ FreeFem++-mpi -v 0 examples/meliga_etal_2012/vortex.md -mo $workdir/vortex
 ```sh
 ff-mpirun -np $nproc basecompute.md -v 0 -dir $workdir -mi vortex.msh -fo vortex -1/Re 0.005 -S 0
 ```
+
 2. Continue base state along the parameter $S$ with adaptive remeshing
 ```sh
 ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi vortex.base -fo vortex -param S -h0 1 -scount 4 -maxcount 40 -mo vortexadapt
 ```
 
 ### Unsteady 3-D dynamics
-1. Compute base state near the double Hopf point
+1. Compute the $m=-1$ Hopf point along $S=1$
+```sh
+ff-mpirun -np $nproc basecompute.md -v 0 -dir $workdir -mi vortex.msh -fo vortexS1m1 -1/Re 0.0061 -S 1
+ff-mpirun -np $nproc modecompute.md -v 0 -dir $workdir -fo vortexS1m1 -fi vortexS1m1.base -sym -1 -eps_target 0.1+1.1i -eps_pos_gen_non_hermitian
+ff-mpirun -np $nproc hopfcompute.md -v 0 -dir $workdir -fo vortexS1m1 -fi vortexS1m1.mode -nf 0 -param 1/Re
+ff-mpirun -np $nproc hopfcompute.md -v 0 -dir $workdir -fo vortexS1m1 -fi vortexS1m1.mode -adaptto bda -mo vortexS1m1 -param 1/Re
+```
+
+2. Compute base state near the double Hopf point
 ```sh
 ff-mpirun -np $nproc basecompute.md -v 0 -dir $workdir -mi vortex.msh -fo vortexDH -1/Re 0.0139 -S 1
 ff-mpirun -np $nproc basecompute.md -v 0 -dir $workdir -fi vortexDH.base -fo vortexDH -S 1.44
 ```
-2. Compute near-critical modes
+
+3. Compute near-critical modes
 ```sh
 ff-mpirun -np $nproc modecompute.md -v 0 -dir $workdir -fo vortexm1 -fi vortexDH.base -sym -1 -eps_target 0+1i -eps_pos_gen_non_hermitian
 ff-mpirun -np $nproc modecompute.md -v 0 -dir $workdir -fo vortexm2 -fi vortexDH.base -sym -2 -eps_target 0+2i -eps_pos_gen_non_hermitian
 ```
-3. Compute Hopf-Hopf point assuming non-resonant interaction
+
+4. Compute Hopf-Hopf point assuming non-resonant interaction
 ```sh
 ff-mpirun -np $nproc hohocompute.md -v 0 -dir $workdir -fo vortexDH -fi vortexm2.mode -fi2 vortexm1.mode -param S -param2 1/Re -nf 0
 ff-mpirun -np $nproc hohocompute.md -v 0 -dir $workdir -fo vortexDHadapt -fi vortexDH.hoho -param S -param2 1/Re -adaptto bda -mo vortexm1m2adapt
 ```
 
-4. Compute Hopf-Hopf point assuming $2:1$ resonant interaction
+5. Compute Hopf-Hopf point assuming $2:1$ resonant interaction
 ```sh
 ff-mpirun -np $nproc hohocompute.md -v 0 -dir $workdir -fo vortexDHadapt21res -fi vortexDHadapt.hoho -param S -param2 1/Re -res1x 2
 ```

--- a/examples/meliga_etal_2012/README.md
+++ b/examples/meliga_etal_2012/README.md
@@ -66,10 +66,10 @@ ff-mpirun -np $nproc modecompute.md -v 0 -dir $workdir -fo vortexm2 -fi vortexDH
 3. Compute Hopf-Hopf point assuming non-resonant interaction
 ```sh
 ff-mpirun -np $nproc hohocompute.md -v 0 -dir $workdir -fo vortexDH -fi vortexm2.mode -fi2 vortexm1.mode -param S -param2 1/Re -nf 0
-ff-mpirun -np $nproc hohocompute.md -v 0 -dir $workdir -fo vortexDH -fi vortexDH.hoho -param S -param2 1/Re -adaptto bda -mo vortexm1m2adapt
+ff-mpirun -np $nproc hohocompute.md -v 0 -dir $workdir -fo vortexDHadapt -fi vortexDH.hoho -param S -param2 1/Re -adaptto bda -mo vortexm1m2adapt
 ```
 
 4. Compute Hopf-Hopf point assuming $2:1$ resonant interaction
 ```sh
-ff-mpirun -np $nproc hohocompute.md -v 0 -dir $workdir -fo vortexDH21res -fi vortexDH.hoho -param S -param2 1/Re -res1x 2
+ff-mpirun -np $nproc hohocompute.md -v 0 -dir $workdir -fo vortexDHadapt21res -fi vortexDHadapt.hoho -param S -param2 1/Re -res1x 2
 ```

--- a/examples/meliga_etal_2012/README.md
+++ b/examples/meliga_etal_2012/README.md
@@ -84,3 +84,4 @@ ff-mpirun -np $nproc hohocompute.md -v 0 -dir $workdir -fo vortexDHadapt -fi vor
 ```sh
 ff-mpirun -np $nproc hohocompute.md -v 0 -dir $workdir -fo vortexDHadapt21res -fi vortexDHadapt.hoho -param S -param2 1/Re -res1x 2
 ```
+NOTE: the resonant coefficients $\gamma_{12}$ and $\gamma_{22}$ differ from the original paper by unit-magnitude phase offset due to a different phase reference condition used by `ff-bifbox`.

--- a/examples/meliga_etal_2012/eqns_meliga_etal_2012.idp
+++ b/examples/meliga_etal_2012/eqns_meliga_etal_2012.idp
@@ -24,13 +24,11 @@
 // Boundary conditions
   macro BoundaryConditions(u, U)
     on(BCinflow, u = U - 1.0, u#y = U#y, u#z = U#z - params["S"]*((y <= 1.0)*y*(2.0 - y^2) + (y > 1.0)/(y+(y == 0))))
-    + on(BCslip, u#y = U#y, u#z = U#z)
-    + on(BCaxis, u#y = U#y, u#z = U#z)
+    + on(BCslip, BCaxis, u#y = U#y, u#z = U#z)
   // EOM
   macro HomBoundaryConditions(u)
     on(BCinflow, u = 0, u#y = 0, u#z = 0)
-    + on(BCslip, u#y = 0, u#z = 0)
-    + on((abs(int(sym(0))) != 1)*BCaxis, u#y = 0, u#z = 0)
+    + on(BCslip, (abs(int(sym(0))) != 1)*BCaxis, u#y = 0, u#z = 0)
     + on((abs(int(sym(0))) >  0)*BCaxis, u = 0)
   // EOM
 // RESIDUAL OPERATOR

--- a/examples/sipp_lebedev_2007/README.md
+++ b/examples/sipp_lebedev_2007/README.md
@@ -85,7 +85,7 @@ ff-mpirun -np $nproc hopfcompute.md -v 0 -dir $workdir -fi cavity4000.mode -fo c
 ff-mpirun -np $nproc hopfcompute.md -v 0 -dir $workdir -fi cylinder.hopf -fo cylinderadapt -mo cylinderhopf -adaptto bda -param 1/Re -thetamax 5 -pv 1 -wnl 1 
 ff-mpirun -np $nproc hopfcompute.md -v 0 -dir $workdir -fi cavity.hopf -fo cavityadapt -mo cavityhopf -adaptto bda -param 1/Re -pv 1 -wnl 1
 ```
-NOTE: the normalizations for the direct and adjoint eigenmodes (and therefore also the weakly-nonlinear corrections) used by `ff-bifbox` are different than the normalizations used by Sipp and Lebedev. This causes the results to differ by a complex scaling factor. Further, the sign of the Stuart-Landau coefficients in Sipp and Lebedev JFM (2007) are opposite to those of the normal form used in `hopfcompute.md`.
+NOTE: the normalizations for the direct and adjoint eigenmodes (and therefore also the weakly-nonlinear corrections) used by `ff-bifbox` are different than the normalizations used by Sipp and Lebedev. This causes the results to differ by a complex scaling factor.
 
 
 ### Harmonic Balance

--- a/fohocompute.md
+++ b/fohocompute.md
@@ -3,12 +3,12 @@ Author: Chris Douglas ([@cmdoug](https://github.com/cmdoug)) [christopher.dougla
 
 This script computes the normal form at a non-degenerate fold–Hopf point.
 
-The normal form is written for the complex amplitude $Y = A \exp(\mathrm{i} \omega t)$ and the real amplitude $Z$ as:
+The normal form is written for the complex amplitude $Y = A_1 \exp(\mathrm{i} \omega t)$ and the real amplitude $A_2$ as:
 
 $$
 \begin{align*}
-\frac{dY}{dt} &= \alpha_1 \cdot \delta\lambda Y + \mathrm{i} \omega Y + \beta_1 Y |Y|^2 + \gamma_{12} Y Z + \gamma_{13} Y Z^2 \\
-\frac{dZ}{dt} &= \alpha_2 \cdot \delta\lambda + \beta_{22} Z^2 + \beta_{23} Z^3 + \gamma_{22} |Y|^2 + \gamma_{23} Z |Y|^2
+\frac{dA_1}{dt} + \alpha_1 \cdot \delta\lambda A_1 + \beta_1 A_1 |A_1|^2 + \gamma_{12} A_1 A_2 + \gamma_{13} A_1 A_2^2 &= 0 \\
+\frac{dA_2}{dt} + \alpha_2 \cdot \delta\lambda + \beta_{22} A_2^2 + \beta_{23} A_2^3 + \gamma_{22} |A_1|^2 + \gamma_{23} A_2 |A_1|^2 &= 0
 \end{align*}
 $$
 
@@ -84,7 +84,7 @@ if (fileext2 == "fold") {
 else if(fileext2 == "foho") {
   real omega;
   complex[string] alpha1;
-  complex beta1, gamma1;
+  complex beta1;
   complex[int] q1m, q1ma;
   ub[].re = loadfoho(fileroot2, meshin, q1m, q1ma, um2[].re, um3[].re, sym, omega, alpha1, alpha2, beta1, beta22, beta23, gamma12, gamma13, gamma22, gamma23);
 }
@@ -101,13 +101,13 @@ else if (fileext1 == "foho" && fileext2 != "") {
 else if (fileext1 == "hoho") {
   real omegaN;
   complex[string] alphaN;
-  complex betaN, gammaN, gamma12, gammaM, gamma22, gamma23;
+  complex betaN, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23;
   complex[int] qNm, qNma;
   if(select == 1){
-    ub[].re = loadhoho(fileroot1, meshin, um[], uma[], qNm, qNma, sym1, sym, omega, omegaN, alpha1, alphaN, beta1, betaN, gamma13, gammaN, gamma12, gammaM, gamma22, gamma23);
+    ub[].re = loadhoho(fileroot1, meshin, um[], uma[], qNm, qNma, sym1, sym, omega, omegaN, alpha1, alphaN, beta1, betaN, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23);
   }
   else if(select == 2){
-    ub[].re = loadhoho(fileroot1, meshin, qNm, qNma, um[], uma[], sym, sym1, omegaN, omega, alphaN, alpha1, betaN, beta1, gammaN, gamma13, gamma12, gammaM, gamma22, gamma23);
+    ub[].re = loadhoho(fileroot1, meshin, qNm, qNma, um[], uma[], sym, sym1, omegaN, omega, alphaN, alpha1, betaN, beta1, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23);
   }
 }
 else if (fileext1 == "hopf") {
@@ -170,9 +170,9 @@ else if(basefileext == "hoho") {
   real[int] sym2(sym.n);
   real omega1, omega2;
   complex[string] alpha1, alpha2;
-  complex beta1, beta2, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23;
+  complex beta1, beta2, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23;
   complex[int] q1m, q1ma, q2m, q2ma;
-  ub[].re = loadhoho(basefileroot, meshin, q1m, q1ma, q2m, q2ma, sym, sym2, omega1, omega2, alpha1, alpha2, beta1, beta2, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23);
+  ub[].re = loadhoho(basefileroot, meshin, q1m, q1ma, q2m, q2ma, sym, sym2, omega1, omega2, alpha1, alpha2, beta1, beta2, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23);
 }
 else if(basefileext == "tdns") {
   real time;
@@ -556,7 +556,7 @@ if (ret > 0) { // Save solution if solver converged and output file is given
         q1P.resize(Ja.n);
         if(mpirank == 0) q1P(Ja.n-1) = 0.0;
         KSPSolve(Ja, q1P, q1P);
-        if(mpirank == 0) alpha2[paramnames[k]] = real(q1P(Ja.n-1));
+        if(mpirank == 0) alpha2[paramnames[k]] = -real(q1P(Ja.n-1));
         broadcast(processor(0), alpha2[paramnames[k]]);
         qDa(k, :) = q1P(0:J.n-1);
       }
@@ -569,7 +569,7 @@ if (ret > 0) { // Save solution if solver converged and output file is given
     p2P.resize(Ja.n);
     if(mpirank == 0) p2P(Ja.n-1) = 0.0;
     KSPSolve(Ja, p2P, p2P);
-    if(mpirank == 0) beta22 = real(p2P(Ja.n-1));
+    if(mpirank == 0) beta22 = -real(p2P(Ja.n-1));
     broadcast(processor(0), beta22);
     p2P.resize(J.n);
 
@@ -586,7 +586,7 @@ if (ret > 0) { // Save solution if solver converged and output file is given
     q1P.resize(Ja.n);
     if(mpirank == 0) q1P(Ja.n-1) = 0.0;
     KSPSolve(Ja, q1P, q1P);
-    if(mpirank == 0) gamma22 = real(q1P(Ja.n-1));
+    if(mpirank == 0) gamma22 = -real(q1P(Ja.n-1));
     broadcast(processor(0), gamma22);
     q1P.resize(J.n);
     //  C: harmonics generation due to quadratic nonlinear interactions
@@ -625,7 +625,7 @@ if (ret > 0) { // Save solution if solver converged and output file is given
     q2P.resize(Ja.n);
     if(mpirank == 0) q2P(Ja.n-1) = 0.0;
     KSPSolve(Ja, q2P, q2P);
-    if(mpirank == 0) gamma12 = q2P(Ja.n-1);
+    if(mpirank == 0) gamma12 = -q2P(Ja.n-1);
     broadcast(processor(0), gamma12);
     q2P.resize(J.n);
     // 3rd-order
@@ -643,7 +643,7 @@ if (ret > 0) { // Save solution if solver converged and output file is given
         updateparam(paramnames[k], paramval);
         um2[] -= R;
         um3[] += um2[]/eps;
-        alpha1[paramnames[k]] = -J(uma[], um3[]);
+        alpha1[paramnames[k]] = J(uma[], um3[]);
       }
     }
     // A|A|^2
@@ -677,7 +677,7 @@ if (ret > 0) { // Save solution if solver converged and output file is given
     ChangeNumbering(J, um2[], p1P, inverse = true, exchange = true); // FreeFEM to PETSc
     um3[] = vH(0, XMh, tgv = -10);
     R += um3[];
-    beta1 = -J(uma[], R);
+    beta1 = J(uma[], R);
 
     // B^3
     //  B: fundamental modification due to cubic self-interaction
@@ -704,7 +704,7 @@ if (ret > 0) { // Save solution if solver converged and output file is given
     IFMACRO(!cubic)
     R = vH(0, XMh, tgv = -10);
     ENDIFMACRO
-    beta23 = -0.5*real(J(uma[], R));
+    beta23 = 0.5*real(J(uma[], R));
 
     // A|B|^2
     //  B: fundamental modification due to cubic self-interaction of fundamental
@@ -736,7 +736,7 @@ if (ret > 0) { // Save solution if solver converged and output file is given
     ChangeNumbering(J, um2[], q2P, inverse = true, exchange = true); // FreeFEM to PETSc
     um3[] = vH(0, XMh, tgv = -10);
     R += um3[];
-    gamma13 = -J(uma[], R);
+    gamma13 = J(uma[], R);
 
     // B|A|^2
     //  B: fundamental modification due to cubic self-interaction of fundamental
@@ -771,7 +771,7 @@ if (ret > 0) { // Save solution if solver converged and output file is given
     ChangeNumbering(J, um2[], q2P, inverse = true, exchange = true); // FreeFEM to PETSc
     um3[] = vH(0, XMh, tgv = -10);
     R += um3[];
-    gamma23 = -real(J(uma[], R));
+    gamma23 = real(J(uma[], R));
     if(wnlsave){
       complex[int] val(1);
       XMh<complex>[int] defu(vec)(1);

--- a/fohocompute.md
+++ b/fohocompute.md
@@ -53,7 +53,7 @@ string param = getARGV("-param", "");
 string param2 = getARGV("-param2", "");
 string adaptto = getARGV("-adaptto", "b");
 real eps = getARGV("-eps", 1e-7);
-real eps2 = getARGV("-eps2", 1e-7);
+real eps2 = getARGV("-eps2", eps);
 string sneslinesearchtype = getARGV("-snes_linesearch_type","basic");
 real TGV = getARGV("-tgv", -1);
 real[int] sym1(sym.n);

--- a/foldcompute.md
+++ b/foldcompute.md
@@ -6,14 +6,13 @@ This script computes the normal form at a non-degenerate fold point.
 The normal form is written for the real amplitude $A$ as:
 
 $$
-\frac{dA}{dt} = \alpha \cdot \delta\lambda + \beta A^2
+\frac{dA}{dt} + \alpha \cdot \delta\lambda + \beta A^2 = 0
 $$
 
 where:
 - $\alpha$ is the coefficient for the term from parameter changes,
 - $\delta\lambda$ are the parameter increments,
 - $\beta$ is the coefficient for the term from harmonic interactions.
-
 
 ## EXAMPLE USAGE:
 ### Initialize with fold guess from base file, solve on same mesh
@@ -99,9 +98,9 @@ else if(fileext == "hoho") {
   real[int] sym1(sym.n), sym2(sym.n);
   real omega1, omega2;
   complex[string] alpha1, alpha2;
-  complex beta1, beta2, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23;
+  complex beta1, beta2, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23;
   complex[int] q1m, q1ma, q2m, q2ma;
-  ub[] = loadhoho(fileroot, meshin, q1m, q1ma, q2m, q2ma, sym1, sym2, omega1, omega2, alpha1, alpha2, beta1, beta2, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23);
+  ub[] = loadhoho(fileroot, meshin, q1m, q1ma, q2m, q2ma, sym1, sym2, omega1, omega2, alpha1, alpha2, beta1, beta2, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23);
 }
 else if(fileext == "tdns") {
   real time;
@@ -306,14 +305,14 @@ if (ret > 0) { // Save solution if solver converged and output file is given
         um2[] = vR(0, XMh, tgv = TGV);
         updateparam(paramnames[k], paramval);
         um2[] -= R;
-        alpha[paramnames[k]] = -J(uma[], um2[])/eps;
+        alpha[paramnames[k]] = J(uma[], um2[])/eps;
       }
     }
     //  B: base modification due to quadratic nonlinear interaction
     ChangeNumbering(J, um[], qm, inverse = true, exchange = true);
     um2[] = um[];
     um3[] = vH(0, XMh, tgv = -10);
-    beta = -0.5*J(uma[], um3[]);
+    beta = 0.5*J(uma[], um3[]);
   }
   else {
     for (int k = 0; k < paramnames.n; ++k){

--- a/foldcontinue.md
+++ b/foldcontinue.md
@@ -385,14 +385,14 @@ while (!stopflag){
           um2[] = vR(0, XMh, tgv = TGV);
           updateparam(paramnames[k], paramval);
           um2[] -= R;
-          alpha[paramnames[k]] = -J(uma[], um2[])/eps;
+          alpha[paramnames[k]] = J(uma[], um2[])/eps;
         }
       }
       //  B: base modification due to quadratic nonlinear interaction
       ChangeNumbering(J, um[], qm, inverse = true, exchange = true);
       um2[] = um[];
       um3[] = vH(0, XMh, tgv = -10);
-      beta = -0.5*J(uma[], um3[]);
+      beta = 0.5*J(uma[], um3[]);
     }
     else {
       for (int k = 0; k < paramnames.n; ++k){

--- a/hohocompute.md
+++ b/hohocompute.md
@@ -7,8 +7,8 @@ The normal form is written for the complex amplitudes $Y = A_1 \exp(\mathrm{i} \
 
 $$
 \begin{align*}
-\frac{dY}{dt} &= \alpha_1 \cdot \delta\lambda Y + \mathrm{i} \omega_1 Y + \beta_1 Y |Y|^2 + \gamma_{11} Y |Z|^2 + \gamma_{12} Z^2 + \gamma_{13} Z^3 \\
-\frac{dZ}{dt} &= \alpha_2 \cdot \delta\lambda Z + \mathrm{i} \omega_2 Z + \beta_2 Z |Z|^2 + \gamma_{21} Z |Y|^2 + \gamma_{22} Y Z^{\ast} + \gamma_{23} Y (Z^{\ast})^2
+\frac{dA_1}{dt} + \alpha_1 \cdot \delta\lambda A_1 + \beta_1 A_1 |A_1|^2 + \gamma_{11} A_1 |A_2|^2 + \gamma_{12} A_2^2 + \gamma_{13} A_2^3 &= 0\\
+\frac{dA_2}{dt} + \alpha_2 \cdot \delta\lambda A_2 + \beta_2 A_2 |A_2|^2 + \gamma_{21} A_2 |A_1|^2 + \gamma_{22} A_1 A_2^{\ast} + \gamma_{23} A_1 (A_2^{\ast})^2 &= 0
 \end{align*}
 $$
 
@@ -62,7 +62,7 @@ real TGV = getARGV("-tgv", -1);
 real[int] sym1(sym.n), sym2(sym.n);
 real omega, omega1, omega2;
 complex[string] alpha1, alpha2;
-complex beta1, beta2, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23;
+complex beta1, beta2, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23;
 // Load mesh, make FE basis
 string fileroot1, fileext1 = parsefilename(filein, fileroot1); //extract file name and extension
 string fileroot2, fileext2 = parsefilename(filein2, fileroot2); //extract file name and extension
@@ -90,13 +90,13 @@ else if (fileext2 == "foho") {
 else if (fileext2 == "hoho") {
   real omegaN;
   complex[string] alphaN;
-  complex betaN, gammaN, gamma12, gamma13, gamma22, gamma23;
+  complex betaN, gammaN1, gammaN2, gammaN3;
   complex[int] qNm, qNma;
   if(select2 == 1){
-    ub[].re = loadhoho(fileroot2, meshin, um2[], um3[], qNm, qNma, sym2, sym, omega2, omegaN, alpha2, alphaN, beta2, betaN, gammaN, gamma2, gamma12, gamma13, gamma22, gamma23);
+    ub[].re = loadhoho(fileroot2, meshin, um2[], um3[], qNm, qNma, sym2, sym, omega2, omegaN, alpha2, alphaN, beta2, betaN, gamma21, gamma22, gamma23, gammaN1, gammaN2, gammaN3);
   }
   else if(select2 == 2){
-    ub[].re = loadhoho(fileroot2, meshin, qNm, qNma, um2[], um3[], sym, sym2, omegaN, omega2, alphaN, alpha2, betaN, beta2, gamma2, gammaN, gamma12, gamma13, gamma22, gamma23);
+    ub[].re = loadhoho(fileroot2, meshin, qNm, qNma, um2[], um3[], sym, sym2, omegaN, omega2, alphaN, alpha2, betaN, beta2, gammaN1, gammaN2, gammaN3, gamma21, gamma22, gamma23);
   }
 }
 else if (fileext2 == "mode") {
@@ -129,18 +129,18 @@ else if(fileext2 == "floq") {
 }
 else if (fileext2 != "") assert(false); // invalid input filetype
 if (fileext1 == "hoho" && fileext2 == "") {
-  ub[].re = loadhoho(fileroot1, meshin, um[], uma[], um2[], um3[], sym1, sym2, omega1, omega2, alpha1, alpha2, beta1, beta2, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23);
+  ub[].re = loadhoho(fileroot1, meshin, um[], uma[], um2[], um3[], sym1, sym2, omega1, omega2, alpha1, alpha2, beta1, beta2, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23);
 }
 else if (fileext1 == "hoho" && fileext2 != "") {
   real omegaN;
   complex[string] alphaN;
-  complex betaN, gammaN, gamma12, gamma13, gamma22, gamma23;
+  complex betaN, gammaN1, gammaN2, gammaN3;
   complex[int] qNm, qNma;
   if(select == 1){
-    ub[].re = loadhoho(fileroot1, meshin, um[], uma[], qNm, qNma, sym1, sym, omega1, omegaN, alpha1, alphaN, beta1, betaN, gamma1, gammaN, gamma12, gamma13, gamma22, gamma23);
+    ub[].re = loadhoho(fileroot1, meshin, um[], uma[], qNm, qNma, sym1, sym, omega1, omegaN, alpha1, alphaN, beta1, betaN, gamma11, gamma12, gamma13, gammaN1, gammaN2, gammaN3);
   }
   else if(select == 2){
-    ub[].re = loadhoho(fileroot1, meshin, qNm, qNma, um[], uma[], sym, sym1, omegaN, omega1, alphaN, alpha1, betaN, beta1, gammaN, gamma1, gamma12, gamma13, gamma22, gamma23);
+    ub[].re = loadhoho(fileroot1, meshin, qNm, qNma, um[], uma[], sym, sym1, omegaN, omega1, alphaN, alpha1, betaN, beta1, gammaN1, gammaN2, gammaN3, gamma11, gamma12, gamma13);
   }
 }
 else if (fileext1 == "foho") {
@@ -212,9 +212,9 @@ else if(basefileext == "hoho") {
   real[int] symN(sym.n);
   real omega1, omega2;
   complex[string] alpha1, alpha2;
-  complex beta1, beta2, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23;
+  complex beta1, beta2, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23;
   complex[int] q1m, q1ma, q2m, q2ma;
-  ub[].re = loadhoho(basefileroot, meshin, q1m, q1ma, q2m, q2ma, sym, symN, omega1, omega2, alpha1, alpha2, beta1, beta2, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23);
+  ub[].re = loadhoho(basefileroot, meshin, q1m, q1ma, q2m, q2ma, sym, symN, omega1, omega2, alpha1, alpha2, beta1, beta2, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23);
 }
 else if(basefileext == "tdns") {
   real time;
@@ -685,7 +685,10 @@ if (ret > 0) { // Save solution if solver converged and output file is given
     ik.im = sym;
     iomega = 1i*(omega1 - omega2);
     J = vJ(XMh, XMh, tgv = TGV);
-    if (res1x != 2) KSPSolve(J, q2P, q2P);
+    if (res1x != 2) {
+      KSPSolve(J, q2P, q2P);
+      gamma22 = 0.0;
+    }
     else {
       ChangeNumbering(J, um[], q2ma, inverse = true, exchange = true);
       um2[] = vM(0, XMh, tgv = -10);
@@ -700,7 +703,7 @@ if (ret > 0) { // Save solution if solver converged and output file is given
       q2P.resize(Ja.n);
       if(mpirank == 0) q2P(Ja.n-1) = 0.0;
       KSPSolve(Ja, q2P, q2P);
-      if(mpirank == 0) gamma22 = q2P(Ja.n-1);
+      if(mpirank == 0) gamma22 = -q2P(Ja.n-1);
       broadcast(processor(0), gamma22);
       q2P.resize(J.n);
     }
@@ -742,7 +745,10 @@ if (ret > 0) { // Save solution if solver converged and output file is given
     ik.im = sym;
     iomega = 2i*omega2;
     J = vJ(XMh, XMh, tgv = TGV);
-    if (res1x != 2) KSPSolve(J, qBB, qBB);
+    if (res1x != 2) {
+      KSPSolve(J, qBB, qBB);
+      gamma12 = 0.0;
+    }
     else {
       ChangeNumbering(J, um[], q1ma, inverse = true, exchange = true);
       um2[] = vM(0, XMh, tgv = -10);
@@ -759,7 +765,7 @@ if (ret > 0) { // Save solution if solver converged and output file is given
       qBB.resize(Ja.n);
       if(mpirank == 0) qBB(Ja.n-1) = 0.0;
       KSPSolve(Ja, qBB, qBB);
-      if(mpirank == 0) gamma12 = qBB(Ja.n-1);
+      if(mpirank == 0) gamma12 = -qBB(Ja.n-1);
       broadcast(processor(0), gamma12);
       qBB.resize(J.n);
     }
@@ -784,7 +790,7 @@ if (ret > 0) { // Save solution if solver converged and output file is given
         updateparam(paramnames[k], paramval);
         um2[] -= R;
         um3[] += um2[]/eps;
-        alpha1[paramnames[k]] = -J(uma[], um3[]);
+        alpha1[paramnames[k]] = J(uma[], um3[]);
       }
     }
     // B
@@ -804,7 +810,7 @@ if (ret > 0) { // Save solution if solver converged and output file is given
         updateparam(paramnames[k], paramval);
         um2[] -= R;
         um3[] += um2[]/eps;
-        alpha2[paramnames[k]] = -J(uma[], um3[]);
+        alpha2[paramnames[k]] = J(uma[], um3[]);
       }
     }
     // A|A|^2
@@ -843,7 +849,7 @@ if (ret > 0) { // Save solution if solver converged and output file is given
     ChangeNumbering(J, um2[], p1P, inverse = true, exchange = true); // FreeFEM to PETSc
     um3[] = vH(0, XMh, tgv = -10);
     R += um3[];
-    beta1 = -J(uma[], R);
+    beta1 = J(uma[], R);
 
     // B|B|^2
     //  B: fundamental modification due to cubic self-interaction of fundamental
@@ -881,7 +887,7 @@ if (ret > 0) { // Save solution if solver converged and output file is given
     ChangeNumbering(J, um2[], qBB, inverse = true, exchange = true); // FreeFEM to PETSc
     um3[] = vH(0, XMh, tgv = -10);
     R += um3[];
-    beta2 = -J(uma[], R);
+    beta2 = J(uma[], R);
 
     // A|B|^2
     //  B: fundamental modification due to cubic self-interaction of fundamental
@@ -927,7 +933,7 @@ if (ret > 0) { // Save solution if solver converged and output file is given
     ChangeNumbering(J, um2[], qAB, inverse = true, exchange = true); // FreeFEM to PETSc
     um3[] = vH(0, XMh, tgv = -10);
     R += um3[];
-    gamma1 = -J(uma[], R);
+    gamma11 = J(uma[], R);
 
 
     // B|A|^2
@@ -975,7 +981,7 @@ if (ret > 0) { // Save solution if solver converged and output file is given
     ChangeNumbering(J, um2[], qAB, inverse = true, exchange = true); // FreeFEM to PETSc
     um3[] = vH(0, XMh, tgv = -10);
     R += um3[];
-    gamma2 = -J(uma[], R);
+    gamma21 = J(uma[], R);
 
     if (res1x == 3){
       // B^3
@@ -1006,7 +1012,7 @@ if (ret > 0) { // Save solution if solver converged and output file is given
       IFMACRO(!cubic)
       R = vH(0, XMh, tgv = -10);
       ENDIFMACRO
-      gamma13 = -J(uma[], R);
+      gamma13 = J(uma[], R);
 
       // A*(B^*)^2
       //  B: fundamental modification due to cubic self-interaction of fundamental
@@ -1049,7 +1055,11 @@ if (ret > 0) { // Save solution if solver converged and output file is given
       um3[] = vH(0, XMh, tgv = -10);
       R += um3[];
 
-      gamma23 = -J(uma[], R);
+      gamma23 = J(uma[], R);
+    }
+    else {
+      gamma13 = 0.0;
+      gamma23 = 0.0;
     }
     if(wnlsave){
       complex[int] val(1);
@@ -1093,11 +1103,11 @@ if (ret > 0) { // Save solution if solver converged and output file is given
     }
     beta1 = 0.0;
     beta2 = 0.0;
-    gamma1 = 0.0;
-    gamma2 = 0.0;
+    gamma11 = 0.0;
     gamma12 = 0.0;
-    gamma22 = 0.0;
     gamma13 = 0.0;
+    gamma21 = 0.0;
+    gamma22 = 0.0;
     gamma23 = 0.0;
   }
   if(mpirank==0 && adapt) { // Save adapted mesh
@@ -1109,6 +1119,6 @@ if (ret > 0) { // Save solution if solver converged and output file is given
   ChangeNumbering(J, uma[], q1ma, inverse = true);
   ChangeNumbering(J, um2[], q2m, inverse = true);
   ChangeNumbering(J, um3[], q2ma, inverse = true);
-  savehoho(fileout, "", meshout, sym1, sym2, omega1, omega2, alpha1, alpha2, beta1, beta2, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23, true, true);
+  savehoho(fileout, "", meshout, sym1, sym2, omega1, omega2, alpha1, alpha2, beta1, beta2, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23, true, true);
 }
 ```

--- a/hohocompute.md
+++ b/hohocompute.md
@@ -56,7 +56,7 @@ string param = getARGV("-param", "");
 string param2 = getARGV("-param2", "");
 string adaptto = getARGV("-adaptto", "b");
 real eps = getARGV("-eps", 1e-7);
-real eps2 = getARGV("-eps2", 1e-7);
+real eps2 = getARGV("-eps2", eps);
 string sneslinesearchtype = getARGV("-snes_linesearch_type","basic");
 real TGV = getARGV("-tgv", -1);
 real[int] sym1(sym.n), sym2(sym.n);
@@ -581,12 +581,13 @@ if (ret > 0) { // Save solution if solver converged and output file is given
   ChangeNumbering(J, ub[], qa(0:J.n-1), inverse = true, exchange = true); // PETSc to FreeFEM
   if(mpirank == 0) paramvals = qa(J.n:Ja.n-1).re;
   broadcast(processor(0), paramvals);
-  updateparam(param, paramvals(0) + eps);
+  updateparam(param, paramvals(0));
   omega1 = zerofreq ? 0.0 : paramvals(1-zerofreq);
   updateparam(param2, paramvals(2-zerofreq));
   omega2 = zerofreq2 ? 0.0 : paramvals(3-zerofreq-zerofreq2);
   ChangeNumbering(J, um[], q1m, inverse = true, exchange = true);
   sym = sym1;
+  ik.im = sym1;
   um2[] = vM(0, XMh, tgv = 0);
   phaserefl = um2[].sum;
   mpiAllReduce(phaserefl, phaseref, mpiCommWorld, mpiSUM);
@@ -601,6 +602,7 @@ if (ret > 0) { // Save solution if solver converged and output file is given
   ChangeNumbering(J, uma[], q1ma);
   ChangeNumbering(J, um[], q2m, inverse = true, exchange = true);
   sym = sym2;
+  ik.im = sym2;
   um2[] = vM(0, XMh, tgv = 0);
   phaserefl = um2[].sum;
   mpiAllReduce(phaserefl, phaseref, mpiCommWorld, mpiSUM);
@@ -674,9 +676,7 @@ if (ret > 0) { // Save solution if solver converged and output file is given
     //  difference harmonic
     ChangeNumbering(J, um2[], q2m, inverse = true, exchange = true);
     um2[] = conj(um2[]);
-    ik.im = sym1;
     ik2.im = -sym2;
-    iomega = 1i*omega1;
     iomega2 = -1i*omega2;
     sym = sym1 - sym2;
     um3[] = vH(0, XMh, tgv = -10);
@@ -690,16 +690,16 @@ if (ret > 0) { // Save solution if solver converged and output file is given
       gamma22 = 0.0;
     }
     else {
-      ChangeNumbering(J, um[], q2ma, inverse = true, exchange = true);
+      um[] = conj(um2[]);
       um2[] = vM(0, XMh, tgv = -10);
       ChangeNumbering(J, um2[], p1P);
       matrix<complex> tempPms = [[p1P]]; // dense array to sparse matrix
-      ChangeOperator(pPM, tempPms, parent = Ja); // send to Mat
-      ChangeNumbering(J, um[], q2m, inverse = true, exchange = true);
+      ChangeOperator(qPM, tempPms, parent = Ja); // send to Mat
+      ChangeNumbering(J, um[], q2ma, inverse = true, exchange = true);
       um2[] = vM(0, XMh, tgv = -10);
       ChangeNumbering(J, um2[], p1P);
       tempPms = [[p1P]]; // dense array to sparse matrix
-      ChangeOperator(qPM, tempPms, parent = Ja); // send to Mat
+      ChangeOperator(pPM, tempPms, parent = Ja); // send to Mat
       q2P.resize(Ja.n);
       if(mpirank == 0) q2P(Ja.n-1) = 0.0;
       KSPSolve(Ja, q2P, q2P);
@@ -761,7 +761,6 @@ if (ret > 0) { // Save solution if solver converged and output file is given
       ChangeNumbering(J, um2[], tempP);
       tempPms = [[tempP]]; // dense array to sparse matrix
       ChangeOperator(qPM, tempPms, parent = Ja); // send to Mat
-      Ja = [[J, qPM], [pPM', 0]]; // make dummy Jacobian
       qBB.resize(Ja.n);
       if(mpirank == 0) qBB(Ja.n-1) = 0.0;
       KSPSolve(Ja, qBB, qBB);

--- a/hohocompute.md
+++ b/hohocompute.md
@@ -749,17 +749,17 @@ if (ret > 0) { // Save solution if solver converged and output file is given
       gamma12 = 0.0;
     }
     else {
-      ChangeNumbering(J, um[], q1ma, inverse = true, exchange = true);
+      ChangeNumbering(J, um[], q1m, inverse = true, exchange = true);
       um2[] = vM(0, XMh, tgv = -10);
       complex[int] tempP(J.n);
       ChangeNumbering(J, um2[], tempP);
       matrix<complex> tempPms = [[tempP]]; // dense array to sparse matrix
-      ChangeOperator(pPM, tempPms, parent = Ja); // send to Mat
-      ChangeNumbering(J, um[], q1m, inverse = true, exchange = true);
+      ChangeOperator(qPM, tempPms, parent = Ja); // send to Mat
+      ChangeNumbering(J, um[], q1ma, inverse = true, exchange = true);
       um2[] = vM(0, XMh, tgv = -10);
       ChangeNumbering(J, um2[], tempP);
       tempPms = [[tempP]]; // dense array to sparse matrix
-      ChangeOperator(qPM, tempPms, parent = Ja); // send to Mat
+      ChangeOperator(pPM, tempPms, parent = Ja); // send to Mat
       qBB.resize(Ja.n);
       if(mpirank == 0) qBB(Ja.n-1) = 0.0;
       KSPSolve(Ja, qBB, qBB);

--- a/hohocompute.md
+++ b/hohocompute.md
@@ -667,8 +667,8 @@ if (ret > 0) { // Save solution if solver converged and output file is given
     iomega = 1i*omega1;
     iomega2 = -iomega;
     um2[] = conj(um[]);
+    um[] *= -1.0;
     um3[] = vH(0, XMh, tgv = -10);
-    um3[].re *= -1.0; // -2.0/2.0
     um3[].im = 0.0;
     ChangeNumbering(J, um3[], q1P); // FreeFEM to PETSc
     KSPSolve(J, q1P, q1P);
@@ -680,7 +680,6 @@ if (ret > 0) { // Save solution if solver converged and output file is given
     iomega2 = -1i*omega2;
     sym = sym1 - sym2;
     um3[] = vH(0, XMh, tgv = -10);
-    um3[] *= -1.0; // -2.0/2.0
     ChangeNumbering(J, um3[], q2P); // FreeFEM to PETSc
     ik.im = sym;
     iomega = 1i*(omega1 - omega2);

--- a/hopfcompute.md
+++ b/hopfcompute.md
@@ -6,7 +6,7 @@ This script computes the normal form at a non-degenerate Hopf point.
 The normal form is written for the complex amplitude $Z = A \exp(\mathrm{i} \omega t)$ as:
 
 $$
-\frac{dZ}{dt} = \alpha \cdot \delta\lambda Z + \mathrm{i} \omega Z + \beta Z |Z|^2
+\frac{dA}{dt} + \alpha \cdot \delta\lambda A + \beta A |A|^2 = 0
 $$
 
 where:
@@ -14,7 +14,7 @@ where:
 - $\delta\lambda$ are the parameter increments,
 - $\beta$ is the coefficient for the term from harmonic interactions.
 
-Using this convention, the bifurcation is supercritical for $\Re(\beta) < 0$, and subcritical for $\Re(\beta) > 0$.
+Using this convention, the bifurcation is supercritical for $\Re(\beta) > 0$, and subcritical for $\Re(\beta) < 0$.
 
 #### RESIDUAL EVALUATION IN MINIMALLY AUGMENTED FORMULATION
 We can directly compute the residual using the varf `vR()`.
@@ -263,13 +263,13 @@ else if (fileext == "foho") {
 else if(fileext == "hoho") {
   real omegaN;
   complex[string] alphaN;
-  complex betaN, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23;
+  complex betaN, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23;
   complex[int] qNm, qNma;
   if(select == 1){
-    ub[].re = loadhoho(fileroot, meshin, um[], uma[], qNm, qNma, sym1, sym, omega, omegaN, alpha, alphaN, beta, betaN, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23);
+    ub[].re = loadhoho(fileroot, meshin, um[], uma[], qNm, qNma, sym1, sym, omega, omegaN, alpha, alphaN, beta, betaN, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23);
   }
   else if(select == 2){
-    ub[].re = loadhoho(fileroot, meshin, qNm, qNma, um[], uma[], sym, sym1, omegaN, omega, alphaN, alpha, betaN, beta, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23);
+    ub[].re = loadhoho(fileroot, meshin, qNm, qNma, um[], uma[], sym, sym1, omegaN, omega, alphaN, alpha, betaN, beta, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23);
   }
 }
 else if (fileext == "mode") {
@@ -329,9 +329,9 @@ else if(basefileext == "hoho") {
   real[int] sym2(sym.n);
   real omega1, omega2;
   complex[string] alpha1, alpha2;
-  complex beta1, beta2, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23;
+  complex beta1, beta2, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23;
   complex[int] q1m, q1ma, q2m, q2ma;
-  ub[].re = loadhoho(basefileroot, meshin, q1m, q1ma, q2m, q2ma, sym, sym2, omega1, omega2, alpha1, alpha2, beta1, beta2, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23);
+  ub[].re = loadhoho(basefileroot, meshin, q1m, q1ma, q2m, q2ma, sym, sym2, omega1, omega2, alpha1, alpha2, beta1, beta2, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23);
 }
 else if(basefileext == "tdns") {
   real time;
@@ -637,7 +637,7 @@ if (ret > 0) { // Save solution if solver converged and output file is given
         updateparam(paramnames[k], paramval);
         um2[] -= R;
         um3[] += um2[]/eps;
-        alpha[paramnames[k]] = -J(uma[], um3[]);
+        alpha[paramnames[k]] = J(uma[], um3[]);
       }
     }
     IFMACRO(cubic)
@@ -670,7 +670,7 @@ if (ret > 0) { // Save solution if solver converged and output file is given
     ChangeNumbering(J, um2[], pP, inverse = true, exchange = true);
     um3[] = vH(0, XMh, tgv = -10);
     R += um3[];
-    beta = -J(uma[], R);
+    beta = J(uma[], R);
     if(wnlsave){
       complex[int] val(1);
       XMh<complex>[int] defu(vec)(1);

--- a/hopfcontinue.md
+++ b/hopfcontinue.md
@@ -88,13 +88,13 @@ if (count == 0){
   else if(fileext == "hoho") {
     real omegaN;
     complex[string] alphaN;
-    complex betaN, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23;
+    complex betaN, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23;
     complex[int] qNm, qNma;
     if(select == 1){
-      ub[].re = loadhoho(fileroot, meshin, um[], uma[], qNm, qNma, sym1, sym, omega, omegaN, alpha, alphaN, beta, betaN, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23);
+      ub[].re = loadhoho(fileroot, meshin, um[], uma[], qNm, qNma, sym1, sym, omega, omegaN, alpha, alphaN, beta, betaN, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23);
     }
     else if(select == 2){
-      ub[].re = loadhoho(fileroot, meshin, qNm, qNma, um[], uma[], sym, sym1, omegaN, omega, alphaN, alpha, betaN, beta, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23);
+      ub[].re = loadhoho(fileroot, meshin, qNm, qNma, um[], uma[], sym, sym1, omegaN, omega, alphaN, alpha, betaN, beta, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23);
     }
   }
   savehopf(filein, (savecount > 0 ? fileout : ""), meshin, sym1, omega, alpha, beta, false, false);
@@ -514,7 +514,7 @@ while (!stopflag){
           updateparam(paramnames[k], paramval);
           um2[] -= temp;
           um3[] += um2[]/eps;
-          alpha[paramnames[k]] = -J(uma[], um3[]);
+          alpha[paramnames[k]] = J(uma[], um3[]);
         }
       }
       IFMACRO(cubic)
@@ -547,7 +547,7 @@ while (!stopflag){
       ChangeNumbering(J, um2[], pP, inverse = true, exchange = true); // FreeFEM to PETSc
       um3[] = vH(0, XMh, tgv = -10);
       temp += um3[];
-      beta = -J(uma[], temp);
+      beta = J(uma[], temp);
       ik2 = 0.0;
       iomega2 = 0.0;
       if(wnlsave){

--- a/macros_bifbox.idp
+++ b/macros_bifbox.idp
@@ -1897,7 +1897,7 @@ macro savetdns(tdnsfileout, statsfile, meshfile, ICfile, time, saveflag, monitor
   }
 }//EOM
 
-macro savehoho(hohofileout, statsfile, meshfile, sym1, sym2, omega1, omega2, alpha1, alpha2, beta1, beta2, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23, saveflag, monitorflag){
+macro savehoho(hohofileout, statsfile, meshfile, sym1, sym2, omega1, omega2, alpha1, alpha2, beta1, beta2, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23, saveflag, monitorflag){
   IFMACRO(getmonitors)
     XMhg defu(tempu), defu(ubg), defu(umg), defu(umag);
     tempu[](restu) = ub[].re;
@@ -1921,7 +1921,7 @@ macro savehoho(hohofileout, statsfile, meshfile, sym1, sym2, omega1, omega2, alp
         cout << "], alpha[" + paramnames[k] + "] = [" + alpha1[paramnames[k]] + "; " + alpha2[paramnames[k]];
       }
     }
-    cout << "], beta = [" + beta1 + "; " + beta2 << "], gamma = [" + gamma1 + "," + gamma12 + "," + gamma13 + "; " + gamma2 + "," + gamma22 + "," + gamma23 +  "]";
+    cout << "], beta = [" + beta1 + "; " + beta2 << "], gamma = [" + gamma11 + ", " + gamma12 + ", " + gamma13 + "; " + gamma21 + ", " + gamma22 + ", " + gamma23 + "]";
     if(paramnames[0] != "" ) cout << ", " << listparams(paramnames, params);
     if(monitornames[0] != "") cout << ", " << listparams(monitornames, monitors);
     cout << "." << endl;
@@ -1939,7 +1939,7 @@ macro savehoho(hohofileout, statsfile, meshfile, sym1, sym2, omega1, omega2, alp
           file << "\t" << alpha1[paramnames[k]] << "\t" << alpha2[paramnames[k]];
         }
       }
-      file << "\t" << beta1 << "\t" << beta2 << "\t" << gamma1 << "\t" << gamma2 << "\t" << gamma12 << "\t" << gamma13 << "\t" << gamma22 << "\t" << gamma23;
+      file << "\t" << beta1 << "\t" << beta2 << "\t" << gamma11 << "\t" << gamma12 << "\t" << gamma13 << "\t" << gamma21 << "\t" << gamma22 << "\t" << gamma23;
       if(paramnames[0] != ""){
         for (int k = 0; k < paramnames.n; ++k){
           file << "\t" << params[paramnames[k]];
@@ -1982,7 +1982,7 @@ macro savehoho(hohofileout, statsfile, meshfile, sym1, sym2, omega1, omega2, alp
           }
         }
         file << "beta\t" << beta1 << "\t" << beta2 << endl;
-        file << "gamma\t" << gamma1 << "\t" << gamma12 << "\t" << gamma13 << "\t" << gamma2 << "\t" << gamma22 << "\t" << gamma23 << endl;
+        file << "gamma\t" << gamma11 << "\t" << gamma12 << "\t" << gamma13 << "\t" << gamma21 << "\t" << gamma22 << "\t" << gamma23 << endl;
         if(paramnames[0] != ""){
           for (int k = 0; k < paramnames.n; ++k){
             file << paramnames[k] << "\t" << params[paramnames[k]] << endl;
@@ -2817,7 +2817,7 @@ func complex[int] loadtdls(string inputfilename, string meshfilename, real[int] 
     }
 
 func real[int] loadhoho(string inputfilename, string meshfilename, complex[int] & q1mlocal, complex[int] & q1malocal, complex[int] & q2mlocal, complex[int] & q2malocal,
-                        real[int] & sym1, real[int] & sym2, real & omega1, real & omega2, complex[string] & alpha1, complex[string] & alpha2, complex & beta1, complex & beta2, complex & gamma1, complex & gamma2, complex & gamma12, complex & gamma13, complex & gamma22, complex & gamma23) {
+                        real[int] & sym1, real[int] & sym2, real & omega1, real & omega2, complex[string] & alpha1, complex[string] & alpha2, complex & beta1, complex & beta2, complex & gamma11, complex & gamma12, complex & gamma13, complex & gamma21, complex & gamma22, complex & gamma23) {
       XMhg defu(ubg);
       XMhg<complex> defu(u1mg), defu(u1mag), defu(u2mg), defu(u2mag);
       if (mpirank == 0) cout << "  Loading '" + inputfilename + ".hoho' on '" + meshfilename + "' from '" + workdir + "'." << endl;
@@ -2831,7 +2831,7 @@ func real[int] loadhoho(string inputfilename, string meshfilename, complex[int] 
         }
       }
       file >> dummy >> beta1 >> beta2;
-      file >> dummy >> gamma1 >> gamma12 >> gamma13 >> gamma2 >> gamma22 >> gamma23;
+      file >> dummy >> gamma11 >> gamma12 >> gamma13 >> gamma21 >> gamma22 >> gamma23;
       if(paramnames[0] != ""){
         for (int k = 0; k < paramnames.n; ++k){
           file >> paramnames[k] >> params[paramnames[k]];
@@ -2852,7 +2852,7 @@ func real[int] loadhoho(string inputfilename, string meshfilename, complex[int] 
             cout << "], alpha[" + paramnames[k] + "] = [" + alpha1[paramnames[k]] + "; " + alpha2[paramnames[k]];
           }
         }
-        cout << "], beta = [" + beta1 + "; " + beta2 + "], gamma = [" + gamma1 + ", " + gamma12 + ", " + gamma13 + "; " + gamma2 + ", " + gamma22 + ", " + gamma23 + "]";
+        cout << "], beta = [" + beta1 + "; " + beta2 + "], gamma = [" + gamma11 + ", " + gamma12 + ", " + gamma13 + "; " + gamma21 + ", " + gamma22 + ", " + gamma23 + "]";
         if(paramnames[0] != "") cout << ", " + listparams(paramnames, params);
         if(monitornames[0] != "") cout << ", " + listparams(monitornames, monitors);
         cout << "." << endl;

--- a/modecompute.md
+++ b/modecompute.md
@@ -88,9 +88,9 @@ else if(fileext == "hoho") {
   real[int] sym1(sym.n), sym2(sym.n);
   real omega1, omega2;
   complex[string] alpha1, alpha2;
-  complex beta1, beta2, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23;
+  complex beta1, beta2, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23;
   complex[int] q1m, q1ma, q2m, q2ma;
-  ub[] = loadhoho(fileroot, meshin, q1m, q1ma, q2m, q2ma, sym1, sym2, omega1, omega2, alpha1, alpha2, beta1, beta2, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23);
+  ub[] = loadhoho(fileroot, meshin, q1m, q1ma, q2m, q2ma, sym1, sym2, omega1, omega2, alpha1, alpha2, beta1, beta2, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23);
 }
 else if(fileext == "tdns") {
   real time;

--- a/porbcompute.md
+++ b/porbcompute.md
@@ -80,13 +80,13 @@ else if (fileext == "foho") {
 else if(fileext == "hoho") {
   real omegaN;
   complex[string] alpha, alphaN;
-  complex beta, betaN, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23;
+  complex beta, betaN, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23;
   complex[int] qma, qNm, qNma;
   if(select == 1){
-    ub[] = loadhoho(fileroot, meshin, um[], qma, qNm, qNma, sym0, sym, omega, omegaN, alpha, alphaN, beta, betaN, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23);
+    ub[] = loadhoho(fileroot, meshin, um[], qma, qNm, qNma, sym0, sym, omega, omegaN, alpha, alphaN, beta, betaN, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23);
   }
   else if(select == 2){
-    ub[] = loadhoho(fileroot, meshin, qNm, qNma, um[], qma, sym, sym0, omegaN, omega, alphaN, alpha, betaN, beta, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23);
+    ub[] = loadhoho(fileroot, meshin, qNm, qNma, um[], qma, sym, sym0, omegaN, omega, alphaN, alpha, betaN, beta, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23);
   }
   uh(:, 0) = um[];
 }
@@ -143,9 +143,9 @@ else if(basefileext == "hoho") {
   real[int] sym2(sym.n);
   real omega1, omega2;
   complex[string] alpha1, alpha2;
-  complex beta1, beta2, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23;
+  complex beta1, beta2, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23;
   complex[int] q1m, q1ma, q2m, q2ma;
-  ub[] = loadhoho(basefileroot, meshin, q1m, q1ma, q2m, q2ma, sym, sym2, omega1, omega2, alpha1, alpha2, beta1, beta2, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23);
+  ub[] = loadhoho(basefileroot, meshin, q1m, q1ma, q2m, q2ma, sym, sym2, omega1, omega2, alpha1, alpha2, beta1, beta2, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23);
 }
 else if(basefileext == "tdns") {
   real time;

--- a/porbcontinue.md
+++ b/porbcontinue.md
@@ -101,13 +101,13 @@ if(count == 0) {
   else if(fileext == "hoho") {
     real omegaN;
     complex[string] alpha, alphaN;
-    complex beta, betaN, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23;
+    complex beta, betaN, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23;
     complex[int] qma, qNm, qNma;
     if(select == 1){
-      ub[] = loadhoho(fileroot, meshin, um[], qma, qNm, qNma, sym0, sym, omega, omegaN, alpha, alphaN, beta, betaN, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23);
+      ub[] = loadhoho(fileroot, meshin, um[], qma, qNm, qNma, sym0, sym, omega, omegaN, alpha, alphaN, beta, betaN, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23);
     }
     else if(select == 2){
-      ub[] = loadhoho(fileroot, meshin, qNm, qNma, um[], qma, sym, sym0, omegaN, omega, alphaN, alpha, betaN, beta, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23);
+      ub[] = loadhoho(fileroot, meshin, qNm, qNma, um[], qma, sym, sym0, omegaN, omega, alphaN, alpha, betaN, beta, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23);
     }
     uh(:, 0) = um[];  
   }

--- a/porbdeflate.md
+++ b/porbdeflate.md
@@ -84,13 +84,13 @@ else if (fileext == "foho") {
 else if(fileext == "hoho") {
   real omegaN;
   complex[string] alpha, alphaN;
-  complex beta, betaN, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23;
+  complex beta, betaN, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23;
   complex[int] qma, qNm, qNma;
   if(select == 1){
-    ub[] = loadhoho(fileroot, meshin, um[], qma, qNm, qNma, sym0, sym, omega, omegaN, alpha, alphaN, beta, betaN, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23);
+    ub[] = loadhoho(fileroot, meshin, um[], qma, qNm, qNma, sym0, sym, omega, omegaN, alpha, alphaN, beta, betaN, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23);
   }
   else if(select == 2){
-    ub[] = loadhoho(fileroot, meshin, qNm, qNma, um[], qma, sym, sym0, omegaN, omega, alphaN, alpha, betaN, beta, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23);
+    ub[] = loadhoho(fileroot, meshin, qNm, qNma, um[], qma, sym, sym0, omegaN, omega, alphaN, alpha, betaN, beta, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23);
   }
   uh(:, 0) = um[];
 }

--- a/printparaview.md
+++ b/printparaview.md
@@ -246,8 +246,8 @@ if (mpirank==0){
     real omega1, omega2;
     real[int] sym1(sym.n), sym2(sym.n);
     complex[string] alpha1, alpha2;
-    complex beta1, beta2, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23;
-    ubg[] = loadhoho(fileroot, meshin, u1mg[], u1mag[], u2mg[], u2mag[], sym1, sym2, omega1, omega2, alpha1, alpha2, beta1, beta2, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23);
+    complex beta1, beta2, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23;
+    ubg[] = loadhoho(fileroot, meshin, u1mg[], u1mag[], u2mg[], u2mag[], sym1, sym2, omega1, omega2, alpha1, alpha2, beta1, beta2, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23);
     cout << "  Saving '" + fileout + "_hoho_[base,dirmode1,adjmode1,dirmode2,adjmode2].vtu' in '" + workdir + "'." << endl;
     real[int] qpv = ubg[];
     complex[int] q1mpv = u1mg[], q1mapv = u1mag[], q2mpv = u2mg[], q2mapv = u2mag[];

--- a/respcompute.md
+++ b/respcompute.md
@@ -75,9 +75,9 @@ else if(fileext == "hoho") {
   real[int] sym1(sym.n), sym2(sym.n);
   real omega1, omega2;
   complex[string] alpha1, alpha2;
-  complex beta1, beta2, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23;
+  complex beta1, beta2, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23;
   complex[int] q1m, q1ma, q2m, q2ma;
-  ub[] = loadhoho(fileroot, meshin, q1m, q1ma, q2m, q2ma, sym1, sym2, omega1, omega2, alpha1, alpha2, beta1, beta2, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23);
+  ub[] = loadhoho(fileroot, meshin, q1m, q1ma, q2m, q2ma, sym1, sym2, omega1, omega2, alpha1, alpha2, beta1, beta2, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23);
 }
 else if(fileext == "tdns") {
   real time;

--- a/rslvcompute.md
+++ b/rslvcompute.md
@@ -79,9 +79,9 @@ else if(fileext == "hoho") {
   real[int] sym1(sym.n), sym2(sym.n);
   real omega1, omega2;
   complex[string] alpha1, alpha2;
-  complex beta1, beta2, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23;
+  complex beta1, beta2, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23;
   complex[int] q1m, q1ma, q2m, q2ma;
-  ub[] = loadhoho(fileroot, meshin, q1m, q1ma, q2m, q2ma, sym1, sym2, omega1, omega2, alpha1, alpha2, beta1, beta2, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23);
+  ub[] = loadhoho(fileroot, meshin, q1m, q1ma, q2m, q2ma, sym1, sym2, omega1, omega2, alpha1, alpha2, beta1, beta2, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23);
 }
 else if(fileext == "tdns") {
   real time;

--- a/tdlscompute.md
+++ b/tdlscompute.md
@@ -112,9 +112,9 @@ if (count == 0){
     real[int] sym2(sym.n);
     real omega1, omega2;
     complex[string] alpha1, alpha2;
-    complex beta1, beta2, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23;
+    complex beta1, beta2, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23;
     complex[int] q1ma(um[].n), q2m(um[].n), q2ma(um[].n);
-    ub[] = loadhoho(fileroot, meshin, um[], q1ma, q2m, q2ma, sym, sym2, omega1, omega2, alpha1, alpha2, beta1, beta2, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23);
+    ub[] = loadhoho(fileroot, meshin, um[], q1ma, q2m, q2ma, sym, sym2, omega1, omega2, alpha1, alpha2, beta1, beta2, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23);
     if(select == 1 && adj) um[] = q1ma;
     else if (select == 2 && !adj) um[] = q2m;
     else if (select == 2 && adj) um[] = q2ma;
@@ -164,9 +164,9 @@ else if(basefileext == "hoho") {
   real[int] sym1(sym.n), sym2(sym.n);
   real omega1, omega2;
   complex[string] alpha1, alpha2;
-  complex beta1, beta2, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23;
+  complex beta1, beta2, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23;
   complex[int] q1m, q1ma, q2m, q2ma;
-  ub[] = loadhoho(basefileroot, meshin, q1m, q1ma, q2m, q2ma, sym1, sym2, omega1, omega2, alpha1, alpha2, beta1, beta2, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23);
+  ub[] = loadhoho(basefileroot, meshin, q1m, q1ma, q2m, q2ma, sym1, sym2, omega1, omega2, alpha1, alpha2, beta1, beta2, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23);
 }
 else if(basefileext == "tdns") {
   real time;

--- a/tdnscompute.md
+++ b/tdnscompute.md
@@ -135,9 +135,9 @@ if (count == 0){
     real[int] sym1(sym.n), sym2(sym.n);
     real omega1, omega2;
     complex[string] alpha1, alpha2;
-    complex beta1, beta2, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23;
+    complex beta1, beta2, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23;
     complex[int] q1m(um[].n), q1ma(um[].n), q2m(um[].n), q2ma(um[].n);
-    ub[] = loadhoho(fileroot, meshin, q1m, q1ma, q2m, q2ma, sym1, sym2, omega1, omega2, alpha1, alpha2, beta1, beta2, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23);
+    ub[] = loadhoho(fileroot, meshin, q1m, q1ma, q2m, q2ma, sym1, sym2, omega1, omega2, alpha1, alpha2, beta1, beta2, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23);
     if(select == 1 && adj) q1m = q1ma;
     else if (select == 2 && !adj) q1m = q2m;
     else if (select == 2 && adj) q1m = q2ma;
@@ -204,9 +204,9 @@ if (count == 0){
     real[int] sym2(sym.n);
     real omega1, omega2;
     complex[string] alpha1, alpha2;
-    complex beta1, beta2, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23;
+    complex beta1, beta2, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23;
     complex[int] q1m, q1ma, q2m, q2ma;
-    ub[] = loadhoho(basefileroot, meshin, q1m, q1ma, q2m, q2ma, sym, sym2, omega1, omega2, alpha1, alpha2, beta1, beta2, gamma1, gamma2, gamma12, gamma13, gamma22, gamma23);
+    ub[] = loadhoho(basefileroot, meshin, q1m, q1ma, q2m, q2ma, sym, sym2, omega1, omega2, alpha1, alpha2, beta1, beta2, gamma11, gamma12, gamma13, gamma21, gamma22, gamma23);
   }
   else if(basefileext == "tdns") {
     real time;


### PR DESCRIPTION
This PR fixes a two bugs in `hohocompute.edp`:

1. A lurking stray `eps` value causing a factor of two error in normal form parameter gradients.
2. A bug where resonant normal form constants were not set to zero when used to initialize non-resonant forms.

It also changes the file I/O for `.hoho` files to enforce a consistent ordering for WNL cross-coupling terms from $\gamma_{11}$ to $\gamma_{23}$.

Additionally, it changes the sign of the Landau constants to match the nonlinear form:

$$
\mathcal{M}\frac{\partial\boldsymbol{q}}{\partial t}+\mathcal{R}(\boldsymbol{q};\boldsymbol{\lambda})=0
$$

For quadratic forms, where the WNL amplitude is $A$, we now have 

$$
\frac{dA}{dt}+\boldsymbol{\alpha}\cdot\delta\boldsymbol{\lambda}+\beta A^2=0.
$$

Similarly, for quadratic forms, where the WNL amplitude is $Z=A\exp(\mathrm{i}\omega t)$, we now have 

$$
\frac{dA}{dt}+\boldsymbol{\alpha}\cdot\delta\boldsymbol{\lambda} A+\beta A |A|^2=0,
$$

such that $\Re(\beta)>0$ and $\Re(\beta)<0$ indicate supercritical and subcritical bifurcations, respectively. 