### PR TITLE
Switch from old `ts_dt` to new `ts_time_step`

### DIFF
--- a/examples/douglas_etal_2023/README.md
+++ b/examples/douglas_etal_2023/README.md
@@ -69,13 +69,13 @@ ff-mpirun -np $nproc basecompute.md -v 0 -dir $workdir -fi ignite_11.base -fo ig
 ff-mpirun -np $nproc basecompute.md -v 0 -dir $workdir -fi ignite_12.base -fo ignite_13 -Da 82 -Ze 1.9
 ff-mpirun -np $nproc basecompute.md -v 0 -dir $workdir -fi ignite_13.base -fo ignite_14 -Da 102 -Ze 1.95 -mo ignite_14
 ff-mpirun -np $nproc basecompute.md -v 0 -dir $workdir -fi ignite_14.base -fo ignite_15 -Da 126 -Ze 2 -mo ignite_15
-ff-mpirun -np $nproc tdnscompute.md -v 0 -dir $workdir -fi ignite_15.base -fo ignitetime -Le 0.7 -Ze 10 -Da 5000 -ts_dt 0.0025 -mo ignitetime -scount 5 -maxcount 120 -pv 1 -ts_adapt_type basic -ts_atol 1e10
+ff-mpirun -np $nproc tdnscompute.md -v 0 -dir $workdir -fi ignite_15.base -fo ignitetime -Le 0.7 -Ze 10 -Da 5000 -ts_time_step 0.0025 -mo ignitetime -scount 5 -maxcount 120 -pv 1 -ts_adapt_type basic -ts_atol 1e10
 ff-mpirun -np $nproc basecompute.md -v 0 -dir $workdir -fi ignitetime_120.tdns -fo conicalflame -mo conicalflame
 ```
 
 3. Compute the $|m|=11$ polyhedral flame bifurcation at $Da=4000$, $Le\sim0.845$.
 ```sh
-ff-mpirun -np $nproc tdnscompute.md -v 0 -dir $workdir -fi conicalflame.base -fo polyhedral -Le 0.845 -Da 4000 -ts_dt 0.0025 -mo polyhedral -scount 5 -maxcount 25 -ts_adapt_type basic -ts_atol 1e10
+ff-mpirun -np $nproc tdnscompute.md -v 0 -dir $workdir -fi conicalflame.base -fo polyhedral -Le 0.845 -Da 4000 -ts_time_step 0.0025 -mo polyhedral -scount 5 -maxcount 25 -ts_adapt_type basic -ts_atol 1e10
 ff-mpirun -np $nproc basecompute.md -v 0 -dir $workdir -fi polyhedral_25.tdns -fo polyhedral -mo polyhedral
 ff-mpirun -np $nproc modecompute.md -v 0 -dir $workdir -fi polyhedral.base -fo polyhedral -sym 11 -eps_target 0.1+0i
 ff-mpirun -np $nproc hopfcompute.md -v 0 -dir $workdir -fi polyhedral.mode -fo polyhedral -param Le -nf 0 -zero 1
@@ -84,7 +84,7 @@ ff-mpirun -np $nproc hopfcompute.md -v 0 -dir $workdir -fi polyhedral.hopf -fo p
 
 4. Compute the $|m|=1$ tilted flame bifurcation at $Le=1.1$, $Da\sim9130$.
 ```sh
-ff-mpirun -np $nproc tdnscompute.md -v 0 -dir $workdir -fi conicalflame.base -fo tilted -Le 1.1 -Da 9135 -ts_dt 0.0025 -mo tilted -scount 5 -maxcount 150 -ts_adapt_type basic -ts_atol 1e10
+ff-mpirun -np $nproc tdnscompute.md -v 0 -dir $workdir -fi conicalflame.base -fo tilted -Le 1.1 -Da 9135 -ts_time_step 0.0025 -mo tilted -scount 5 -maxcount 150 -ts_adapt_type basic -ts_atol 1e10
 ff-mpirun -np $nproc basecompute.md -v 0 -dir $workdir -fi tilted_150.tdns -fo tilted -mo tilted
 ff-mpirun -np $nproc modecompute.md -v 0 -dir $workdir -fi tilted.base -fo tilted -sym 1 -eps_target 0.1+0i
 ff-mpirun -np $nproc hopfcompute.md -v 0 -dir $workdir -fi tilted.mode -fo tilted -param Da -zero 1 -nf 0 -snes_divergence_tolerance 1e8
@@ -99,7 +99,7 @@ ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi polyhedral.base -fo 
 
 6. Continue the base flow along $Da$ at $Le=1$. (very slow!)
 ```sh
-ff-mpirun -np $nproc tdnscompute.md -v 0 -dir $workdir -fi conicalflame.base -fo conicalflame -Le 1 -Da 4000 -ts_dt 0.0025 -mo conicalflame -scount 5 -maxcount 60 -pv 1 -ts_adapt_type basic -ts_atol 1e10
+ff-mpirun -np $nproc tdnscompute.md -v 0 -dir $workdir -fi conicalflame.base -fo conicalflame -Le 1 -Da 4000 -ts_time_step 0.0025 -mo conicalflame -scount 5 -maxcount 60 -pv 1 -ts_adapt_type basic -ts_atol 1e10
 ff-mpirun -np $nproc basecompute.md -v 0 -dir $workdir -fi conicalflame_60.tdns -fo Le1Da4000 -mo Le1Da4000
 ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi Le1Da4000.base -fo Le1Daup -mo Le1Daup -param Da -h0 10 -scount 5 -maxcount 1000
 ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi Le1Da4000.base -fo Le1Dadown -mo Le1Dadown -param Da -h0 -10 -scount 5 -maxcount 500

--- a/examples/wang_etal_2024/README.md
+++ b/examples/wang_etal_2024/README.md
@@ -109,6 +109,6 @@ ff-mpirun -np $nproc rslvcompute.md -v 0 -dir $workdir -fi U03p4.base -fo Re2586
 ```sh
 ff-mpirun -np $nproc modecompute.md -v 0 -dir $workdir -fi U02p6.base -fo Re1978flametip -eps_target 1+600i -pv 1
 ff-mpirun -np 1 examples/wang_etal_2024/moderescale.md -v 0 -dir $workdir -fi Re1978flametip.mode -fo Re1978flametip_scaled
-ff-mpirun -np $nproc tdnscompute.md -v 0 -dir $workdir -bfi U02p6.base -fi Re1978flametip_scaled.mode -fo Re1978perturbation20perc -amp 0.2 -ts_dt 0.0001 -ts_adapt none -scount 2 -maxcount 6000 -mo Re1978perturbation20perc
-ff-mpirun -np $nproc tdnscompute.md -v 0 -dir $workdir -bfi U02p6.base -fi Re1978flametip_scaled.mode -fo Re1978perturbation50perc -amp 0.5 -ts_dt 0.0001 -ts_adapt none -scount 2 -maxcount 6000 -mo Re1978perturbation50perc
+ff-mpirun -np $nproc tdnscompute.md -v 0 -dir $workdir -bfi U02p6.base -fi Re1978flametip_scaled.mode -fo Re1978perturbation20perc -amp 0.2 -ts_time_step 0.0001 -ts_adapt none -scount 2 -maxcount 6000 -mo Re1978perturbation20perc
+ff-mpirun -np $nproc tdnscompute.md -v 0 -dir $workdir -bfi U02p6.base -fi Re1978flametip_scaled.mode -fo Re1978perturbation50perc -amp 0.5 -ts_time_step 0.0001 -ts_adapt none -scount 2 -maxcount 6000 -mo Re1978perturbation50perc
 ```

--- a/tdlscompute.md
+++ b/tdlscompute.md
@@ -30,7 +30,7 @@ int savecount = getARGV("-scount", 1);
 int maxcount = getARGV("-maxcount", 100);
 string tstype = getARGV("-ts_type", "bdf");
 int tsmaxsnesfailures = getARGV("-ts_max_snes_failures", -1);
-real tsdt = getARGV("-ts_dt", 0.01);
+real tstimestep = getARGV("-ts_time_step", 0.01);
 string tsadapttype = getARGV("-ts_adapt_type", "none");
 string sneslinesearchtype = getARGV("-snes_linesearch_type","basic");
 
@@ -215,9 +215,9 @@ func int funcJ(real t, PetscScalar[int]& qPETSc, PetscScalar[int]& qdotPETSc, re
 // Function to monitor solution progress
 func int funcMon(int s, real t, PetscScalar[int]& in) {
     if(s > 0){
-      tsdt = t - time;
+      tstimestep = t - time;
       count++;
-      if(mpirank == 0) cout << "  " << count + ":\tdt = " + tsdt + ",\ttime = " + t << endl;
+      if(mpirank == 0) cout << "  " << count + ":\tdt = " + tstimestep + ",\ttime = " + t << endl;
       ChangeNumbering(J, um[], in, inverse = true);
       savetdls(fileout + "_" + count, ((savecount > 0) ? fileout : ""), meshin, basefilein, filein, sym, t, (count % savecount == 0))
     }
@@ -230,7 +230,7 @@ set(J, IFMACRO(Jsetargs) Jsetargs, ENDIFMACRO sparams = KSPparams);
 TSSolve(J, funcJ, funcF, qc, monitor = funcMon, sparams = " -ts_init_time " + time
                                                        + " -ts_type " + tstype
                                                        + " -ts_max_snes_failures " + tsmaxsnesfailures
-                                                       + " -ts_dt " + tsdt
+                                                       + " -ts_time_step " + tstimestep
                                                        + " -ts_max_steps " + (maxcount-count)
                                                        + " -ts_adapt_type " + tsadapttype
                                                        + " -snes_linesearch_type " + sneslinesearchtype

--- a/tdnscompute.md
+++ b/tdnscompute.md
@@ -36,7 +36,7 @@ int savecount = getARGV("-scount", 1);
 int maxcount = getARGV("-maxcount", 100);
 string tstype = getARGV("-ts_type", "bdf");
 int tsmaxsnesfailures = getARGV("-ts_max_snes_failures", -1);
-real tsdt = getARGV("-ts_dt", 0.01);
+real tstimestep = getARGV("-ts_time_step", 0.01);
 string tsadapttype = getARGV("-ts_adapt_type", "none");
 string sneslinesearchtype = getARGV("-snes_linesearch_type", "basic");
 real TGV = getARGV("-tgv", -1);
@@ -261,9 +261,9 @@ func int funcJ(real t, real[int]& qPETSc, real[int]& qdotPETSc, real a) {
 // Function to monitor solution progress
 func int funcMon(int s, real t, real[int]& in) {
     if(s > 0){
-      tsdt = t - time;
+      tstimestep = t - time;
       count++;
-      if(mpirank == 0) cout << "  " << ((adapt && adaptflag) ? "A" : "") << count + ":\tdt = " + tsdt + ",\ttime = " + t << endl;
+      if(mpirank == 0) cout << "  " << ((adapt && adaptflag) ? "A" : "") << count + ":\tdt = " + tstimestep + ",\ttime = " + t << endl;
       if( adapt ? (adaptflag ? false : (count % savecount != 0)) : true){
         qp = in;
         ChangeNumbering(J, ub[], in, inverse = true);
@@ -283,7 +283,7 @@ while (count < maxcount){
   TSSolve(J, funcJ, funcF, q, monitor = funcMon, reason = ret, sparams = " -ts_init_time " + time
                                                        + " -ts_type " + tstype
                                                        + " -ts_max_snes_failures " + tsmaxsnesfailures
-                                                       + " -ts_dt " + tsdt
+                                                       + " -ts_time_step " + tstimestep
                                                        + " -ts_max_steps " + (adapt ? min(maxcount-count,savecount-(count % (savecount))) : (maxcount-count))
                                                        + " -ts_adapt_type " + tsadapttype
                                                        + " -snes_linesearch_type " + sneslinesearchtype
@@ -339,11 +339,11 @@ while (count < maxcount){
     ChangeNumbering(J, um[], q);
     adaptflag = 1;
     count--;
-    time -= tsdt;
+    time -= tstimestep;
     TSSolve(J, funcJ, funcF, q, monitor = funcMon, reason = ret, sparams = " -ts_init_time " + time
                                                        + " -ts_type " + tstype
                                                        + " -ts_max_snes_failures " + tsmaxsnesfailures
-                                                       + " -ts_dt " + tsdt
+                                                       + " -ts_time_step " + tstimestep
                                                        + " -snes_linesearch_type " + sneslinesearchtype
                                                        + " -ts_max_steps 1 -ts_adapt_type none -options_left no "
                                                        );


### PR DESCRIPTION
Avoids `** PETSc DEPRECATION WARNING ** : the option -ts_dt is deprecated as of version 3.25 and will be removed in a future release.`