### PR TITLE
Simplify `settings.idp` file: ParaView arrays and forcing macros

### DIFF
--- a/examples/.ci-suite/2d-brusselator_settings.idp
+++ b/examples/.ci-suite/2d-brusselator_settings.idp
@@ -21,9 +21,8 @@
   func Pk = [P2, P2];
 // Define quantities for mesh adaptation and plotting in ParaView
   macro adaptu(u)u, u#Y//EOM
-// Names for ParaView outputs
+// Names for ParaView output
   string[int] ParaViewNames = ["X", "Y"];
-  string[int] ParaViewNamesf = ParaViewNames;
   macro InitialConditions()[params["A"], params["B"]/params["A"]]//EOM
 // Boundary labels
   int BCnull = 0;

--- a/examples/.ci-suite/2d-brusselator_settings.idp
+++ b/examples/.ci-suite/2d-brusselator_settings.idp
@@ -19,13 +19,8 @@
   macro defu(u)[u, u#Y]//EOM
   macro initu(i)[i, i]//EOM
   func Pk = [P2, P2];
-// Define forcing vector and FE space (for resolvent analysis)
-  macro deff(f)[f, f#Y]//EOM
-  macro initf(i)[i, i]//EOM
-  func Pkf = [P2, P2];
 // Define quantities for mesh adaptation and plotting in ParaView
   macro adaptu(u)u, u#Y//EOM
-  macro adaptf(f)f, f#Y//EOM
 // Names for ParaView outputs
   string[int] ParaViewNames = ["X", "Y"];
   string[int] ParaViewNamesf = ParaViewNames;

--- a/examples/.ci-suite/2d-brusselator_settings.idp
+++ b/examples/.ci-suite/2d-brusselator_settings.idp
@@ -23,20 +23,12 @@
   macro deff(f)[f, f#Y]//EOM
   macro initf(i)[i, i]//EOM
   func Pkf = [P2, P2];
-// Define quantities for mesh adaptation and plotting in Paraview
+// Define quantities for mesh adaptation and plotting in ParaView
   macro adaptu(u)u, u#Y//EOM
   macro adaptf(f)f, f#Y//EOM
-// Name and order for real Paraview outputs
-  string ParaviewDataName = "X Y";
-  string ParaviewDataNamef = ParaviewDataName;
-  int[int] ParaviewOrder = [1, 1];
-  int[int] ParaviewOrderf = ParaviewOrder;
-// Name and order for complex Paraview outputs
-  string ParaviewDataNamec = "X_r Y_r X_i Y_i";
-  string ParaviewDataNamefc = ParaviewDataNamec;
-  int[int] ParaviewOrderc = [ParaviewOrder, ParaviewOrder];
-  int[int] ParaviewOrderfc = ParaviewOrderc;
-  // Initial conditions (if no file)
+// Names for ParaView outputs
+  string[int] ParaViewNames = ["X", "Y"];
+  string[int] ParaViewNamesf = ParaViewNames;
   macro InitialConditions()[params["A"], params["B"]/params["A"]]//EOM
 // Boundary labels
   int BCnull = 0;

--- a/examples/.ci-suite/2d-buckling_settings.idp
+++ b/examples/.ci-suite/2d-buckling_settings.idp
@@ -25,11 +25,6 @@
     monitors["dispX"] = real(ubg(0., 0.));
     monitors["dispY"] = real(ubgy(0., 0.));
   }// EOM
-//
-/* 
-    The items below are details that don't need to be covered in the tutorial!
-*/
-//
 // Boundary labels on the mesh
   int BCnull = 0;
   int BCpin = 1;
@@ -40,20 +35,11 @@
   macro deff(f)[f, f#y]//EOM
   macro initf(i)[i, i]//EOM
   func Pkf = [P2, P2];
-// Define quantities for mesh adaptation and/or plotting in Paraview
+// Define quantities for mesh adaptation and/or plotting in ParaView
   macro adaptu(u)[u, u#y]//EOM
   macro adaptf(f)[f, f#y]//EOM
-// Name and order for real Paraview outputs
-  string ParaviewDataName = "disp";
-  string ParaviewDataNamef = ParaviewDataName;
-  int[int] ParaviewOrder = [1];
-  int[int] ParaviewOrderf = ParaviewOrder;
-// Name and order for complex Paraview outputs
-  string ParaviewDataNamec = ParaviewDataName + "_r " + ParaviewDataName + "_i";
-  string ParaviewDataNamefc = ParaviewDataNamec;
-  int[int] ParaviewOrderc = [ParaviewOrder, ParaviewOrder];
-  int[int] ParaviewOrderfc = ParaviewOrderc;
-  // Initial conditions (if no file)
-  macro InitialConditions()initu(0)//EOM
+// Names for ParaView outputs
+  string[int] ParaViewNames = ["disp"];
+  string[int] ParaViewNamesf = ParaViewNames;
 // coordinate mapping macros ---------------------------------------------------
   macro coordinatetransform(U) x + real(U), y + real(U#y) // EOM

--- a/examples/.ci-suite/2d-buckling_settings.idp
+++ b/examples/.ci-suite/2d-buckling_settings.idp
@@ -33,8 +33,7 @@
   int BCxsym = 7;
 // Define quantities for mesh adaptation and/or plotting in ParaView
   macro adaptu(u)[u, u#y]//EOM
-// Names for ParaView outputs
+// Names for ParaView output
   string[int] ParaViewNames = ["disp"];
-  string[int] ParaViewNamesf = ParaViewNames;
 // coordinate mapping macros ---------------------------------------------------
   macro coordinatetransform(U) x + real(U), y + real(U#y) // EOM

--- a/examples/.ci-suite/2d-buckling_settings.idp
+++ b/examples/.ci-suite/2d-buckling_settings.idp
@@ -31,13 +31,8 @@
   int BCfree = 5;
   int BCtop = 6;
   int BCxsym = 7;
-// Define forcing vector and FE space (for resolvent analysis, not needed for this example)
-  macro deff(f)[f, f#y]//EOM
-  macro initf(i)[i, i]//EOM
-  func Pkf = [P2, P2];
 // Define quantities for mesh adaptation and/or plotting in ParaView
   macro adaptu(u)[u, u#y]//EOM
-  macro adaptf(f)[f, f#y]//EOM
 // Names for ParaView outputs
   string[int] ParaViewNames = ["disp"];
   string[int] ParaViewNamesf = ParaViewNames;

--- a/examples/.ci-suite/2d-cylinder_settings.idp
+++ b/examples/.ci-suite/2d-cylinder_settings.idp
@@ -21,20 +21,13 @@
   macro deff(f)[f, f#y]//EOM
   macro initf(i)[i, i]//EOM
   func Pkf = [P1b, P1b];
-// Define quantities for mesh adaptation and plotting in Paraview
+// Define quantities for mesh adaptation and plotting in ParaView
   macro adaptu(u)[u, u#y], u#p//EOM
   macro adaptf(f)[f, f#y] //EOM
-// Name and order for real Paraview outputs
-  string ParaviewDataName = "velocity pressure";
-  string ParaviewDataNamef = "momentum";
-  int[int] ParaviewOrder = [1, 1];
-  int[int] ParaviewOrderf = [1];
-// Name and order for complex Paraview outputs
-  string ParaviewDataNamec = "velocity_r pressure_r velocity_i pressure_i";
-  string ParaviewDataNamefc = "momentum_r momentum_i";
-  int[int] ParaviewOrderc = [ParaviewOrder, ParaviewOrder];
-  int[int] ParaviewOrderfc = [ParaviewOrderf, ParaviewOrderf];
-  // Initial conditions (if no file)
+// Names for ParaView outputs
+  string[int] ParaViewNames = ["velocity", "pressure"];
+  string[int] ParaViewNamesf = ["momentum"];
+// Initial conditions (if no file)
   macro InitialConditions()[1, 0, 0]//EOM
 // Boundary labels
   int BCnull = 0;

--- a/examples/FK_problem/settings_FK.idp
+++ b/examples/FK_problem/settings_FK.idp
@@ -22,20 +22,12 @@ func Pk = P2; // FE space for state variable, P1 could also be used
 macro deff(f) f// EOM
 macro initf(i) i// EOM
 func Pkf = P2; // FE space for forcing vector
-// Define quantities for mesh adaptation and plotting in Paraview
+// Define quantities for mesh adaptation and plotting in ParaView
 macro adaptu(u) u// EOM
 macro adaptf(f) f// EOM
-// Name and order for real Paraview outputs
-string ParaviewDataName = "temperature";
-int[int] ParaviewOrder = [1];
-int[int] ParaviewOrderf = [1];
-// Name and order for complex Paraview outputs
-string ParaviewDataNamec = "temperature_r temperature_i";
-string ParaviewDataNamefc = "forcing_r forcing_i";
-int[int] ParaviewOrderc = [ParaviewOrder, ParaviewOrder];
-int[int] ParaviewOrderfc = [ParaviewOrderf, ParaviewOrderf];
-// Initial conditions (if no file)
-macro InitialConditions() 0// EOM
+// Names for ParaView outputs
+string[int] ParaViewNames = ["temperature"];
+string[int] ParaViewNamesf = ["forcing"];
 // Boundary labels 
 int BCnull = 0;
 int BCwall = 1;

--- a/examples/brokof_etal_2024/settings_brokof_etal_2024.idp
+++ b/examples/brokof_etal_2024/settings_brokof_etal_2024.idp
@@ -21,20 +21,15 @@
   macro deff(f)[f, f#y]//EOM
   macro initf(i)[i, i]//EOM
   func Pkf = [P2, P2];
-// Define quantities for mesh adaptation and plotting in Paraview
+// Define quantities for mesh adaptation and plotting in ParaView
   macro adaptu(u)[u, u#y], u#T, u#Y, u#p//EOM
   macro adaptf(f)[f, f#y]//EOM
-// Name and order for real Paraview outputs
-  string ParaviewDataName = "velocity temperature species pressure";
-  string ParaviewDataNamef = "momentum";
-  int[int] ParaviewOrder = [1, 1, 1, 1];
-  int[int] ParaviewOrderf = [1];
-// Name and order for complex Paraview outputs
-  string ParaviewDataNamec = "velocity_r temperature_r species_r pressure_r velocity_i temperature_i species_i pressure_i";
-  string ParaviewDataNamefc = "momentum_r momentum_i";
-  int[int] ParaviewOrderc = [ParaviewOrder, ParaviewOrder];
-  int[int] ParaviewOrderfc = [ParaviewOrderf, ParaviewOrderf];
-  // Initial conditions (if no file)
+  macro paraviewu(u)[u, u#y, 0*u], u#T, u#Y, u#p//EOM
+  macro paraviewf(f)[f, f#y, 0*f] //EOM
+// Names for ParaView outputs
+  string[int] ParaViewNames = ["velocity", "temperature", "species", "pressure"];
+  string[int] ParaViewNamesf = ["momentum"];
+// Initial conditions (if no file)
   macro InitialConditions()[0, 0, 1, 1, 0]//EOM
 // Boundary labels
   int BCnull = 0;

--- a/examples/chakravarthy_etal_2018/settings_chakravarthy_etal_2018.idp
+++ b/examples/chakravarthy_etal_2018/settings_chakravarthy_etal_2018.idp
@@ -25,21 +25,13 @@
   macro deff(f)[f, f#y]//EOM
   macro initf(i)[i, i]//EOM
   func Pkf = [P2, P2];
-// Define quantities for mesh adaptation and plotting in Paraview
+// Define quantities for mesh adaptation and plotting in ParaView
   macro adaptu(u)[u, u#y], u#T, u#p//EOM
   macro adaptf(u)[u, u#y]//EOM
-// Name and order for real Paraview outputs
-  string ParaviewDataName = "velocity temperature pressure";
-  string ParaviewDataNamef = "momentum";
-  int[int] ParaviewOrder = [1, 1, 1];
-  int[int] ParaviewOrderf = [1];
-// Name and order for complex Paraview outputs
-  string ParaviewDataNamec = "velocity_r temperature_r pressure_r";
-  ParaviewDataNamec = ParaviewDataNamec + " velocity_i temperature_i pressure_i";
-  string ParaviewDataNamefc = "momentum_r momentum_i";
-  int[int] ParaviewOrderc = [ParaviewOrder,ParaviewOrder];
-  int[int] ParaviewOrderfc = [ParaviewOrderf,ParaviewOrderf];
-  // Initial conditions (if no file)
+// Names for ParaView outputs
+  string[int] ParaViewNames = ["velocity", "temperature", "pressure"];
+  string[int] ParaViewNamesf = ["momentum"];
+// Initial conditions (if no file)
   macro Uinlet()( (y == 0) ? 1.0 : (0.5 + 0.5*tanh(2.5*(1/(y + (y==0)) - y))) ) // EOM
   macro InitialConditions()[Uinlet, 0, 1, 0]//EOM
 // Boundary labels

--- a/examples/chevalier_etal_2024/settings_chevalier_etal_2024.idp
+++ b/examples/chevalier_etal_2024/settings_chevalier_etal_2024.idp
@@ -26,20 +26,13 @@
 // Define quantities for mesh adaptation
   macro adaptu(u)[u, u#y, u#z], log(max(u#v,1.e-6)), u#p//EOM
   macro adaptf(f)[f, f#y, f#z]//EOM
-// Define quantities for plotting in Paraview
+// Define quantities for plotting in ParaView
   macro paraviewu(u)[u, u#y, u#z], u#v, u#p//EOM
   macro paraviewf(f)[f, f#y, f#z]//EOM
-// Name and order for real Paraview outputs
-  string ParaviewDataName = "velocity nutilde pressure";
-  string ParaviewDataNamef = "momentum";
-  int[int] ParaviewOrder = [1, 1, 1];
-  int[int] ParaviewOrderf = [1];
-// Name and order for complex Paraview outputs
-  string ParaviewDataNamec = "velocity_r nutilde_r pressure_r velocity_i nutilde_i pressure_i";
-  string ParaviewDataNamefc = "momentum_r momentum_i";
-  int[int] ParaviewOrderc = [ParaviewOrder, ParaviewOrder];
-  int[int] ParaviewOrderfc = [ParaviewOrderf, ParaviewOrderf];
-  // Initial conditions (if no file)
+// Names for ParaView outputs
+  string[int] ParaViewNames = ["velocity", "nutilde", "pressure"];
+  string[int] ParaViewNamesf = ["momentum"];
+// Initial conditions (if no file)
   macro InitialConditions()[1,0,0,1e-6,0]//EOM
 // Boundary labels
 int BCnull = 0;

--- a/examples/douglas_2024/settings_douglas_2024_balanced.idp
+++ b/examples/douglas_2024/settings_douglas_2024_balanced.idp
@@ -21,20 +21,13 @@
   macro deff(f)[f, f#y, f#z]//EOM
   macro initf(i)[i, i, i]//EOM
   func Pkf = [P2, P2, P2];
-// Define quantities for mesh adaptation and plotting in Paraview
+// Define quantities for mesh adaptation and plotting in ParaView
   macro adaptu(u)[u, u#y, u#z], u#p//EOM
   macro adaptf(f)[f, f#y, f#z]//EOM
-// Name and order for real Paraview outputs
-  string ParaviewDataName = "velocity pressure";
-  string ParaviewDataNamef = "momentum";
-  int[int] ParaviewOrder = [1, 1];
-  int[int] ParaviewOrderf = [1];
-// Name and order for complex Paraview outputs
-  string ParaviewDataNamec = "velocity_r pressure_r velocity_i pressure_i";
-  string ParaviewDataNamefc = "momentum_r momentum_i";
-  int[int] ParaviewOrderc = [ParaviewOrder, ParaviewOrder];
-  int[int] ParaviewOrderfc = [ParaviewOrderf, ParaviewOrderf];
-  // Initial conditions (if no file)
+// Names for ParaView outputs
+  string[int] ParaViewNames = ["velocity", "pressure"];
+  string[int] ParaViewNamesf = ["momentum"];
+// Initial conditions (if no file)
   macro InitialConditions()[1, 0, (params["S"]*((y<=1)*y*(2-y^2) + (y>1)/(y+(y==0)))), 0, 0]//EOM
 // Boundary labels
   int BCnull = 0;

--- a/examples/douglas_2024/settings_douglas_2024_convect.idp
+++ b/examples/douglas_2024/settings_douglas_2024_convect.idp
@@ -21,20 +21,13 @@
   macro deff(f)[f, f#y, f#z]//EOM
   macro initf(i)[i, i, i]//EOM
   func Pkf = [P2, P2, P2];
-// Define quantities for mesh adaptation and plotting in Paraview
+// Define quantities for mesh adaptation and plotting in ParaView
   macro adaptu(u)[u, u#y, u#z], u#p//EOM
   macro adaptf(f)[f, f#y, f#z]//EOM
-// Name and order for real Paraview outputs
-  string ParaviewDataName = "velocity pressure";
-  string ParaviewDataNamef = "momentum";
-  int[int] ParaviewOrder = [1, 1];
-  int[int] ParaviewOrderf = [1];
-// Name and order for complex Paraview outputs
-  string ParaviewDataNamec = "velocity_r pressure_r velocity_i pressure_i";
-  string ParaviewDataNamefc = "momentum_r momentum_i";
-  int[int] ParaviewOrderc = [ParaviewOrder, ParaviewOrder];
-  int[int] ParaviewOrderfc = [ParaviewOrderf, ParaviewOrderf];
-  // Initial conditions (if no file)
+// Names for ParaView outputs
+  string[int] ParaViewNames = ["velocity", "pressure"];
+  string[int] ParaViewNamesf = ["momentum"];
+// Initial conditions (if no file)
   macro InitialConditions()[1, 0, (params["S"]*((y<=1)*y*(2-y^2) + (y>1)/(y+(y==0)))), 0]//EOM
 // Boundary labels
   int BCnull = 0;

--- a/examples/douglas_2024/settings_douglas_2024_freeout.idp
+++ b/examples/douglas_2024/settings_douglas_2024_freeout.idp
@@ -21,19 +21,13 @@
   macro deff(f)[f, f#y, f#z]//EOM
   macro initf(i)[i, i, i]//EOM
   func Pkf = [P2, P2, P2];
-// Define quantities for mesh adaptation and plotting in Paraview
+// Define quantities for mesh adaptation and plotting in ParaView
   macro adaptu(u)[u, u#y, u#z], u#p//EOM
   macro adaptf(f)[f, f#y, f#z]//EOM
-// Name and order for real Paraview outputs
-  string ParaviewDataName = "velocity pressure";
-  string ParaviewDataNamef = "momentum";
-  int[int] ParaviewOrder = [1, 1];
-  int[int] ParaviewOrderf = [1];
-// Name and order for complex Paraview outputs
-  string ParaviewDataNamec = "velocity_r pressure_r velocity_i pressure_i";
-  string ParaviewDataNamefc = "momentum_r momentum_i";
-  int[int] ParaviewOrderc = [ParaviewOrder, ParaviewOrder];
-  int[int] ParaviewOrderfc = [ParaviewOrderf, ParaviewOrderf];
+// Names for ParaView outputs
+  string[int] ParaViewNames = ["velocity", "pressure"];
+  string[int] ParaViewNamesf = ["momentum"];
+// Initial conditions (if no file)
   // Initial conditions (if no file)
   macro InitialConditions()[1, 0, (params["S"]*((y<=1)*y*(2-y^2) + (y>1)/(y+(y==0)))), 0]//EOM
 // Boundary labels

--- a/examples/douglas_2024/settings_douglas_2024_modified.idp
+++ b/examples/douglas_2024/settings_douglas_2024_modified.idp
@@ -21,19 +21,13 @@
   macro deff(f)[f, f#y, f#z]//EOM
   macro initf(i)[i, i, i]//EOM
   func Pkf = [P2, P2, P2];
-// Define quantities for mesh adaptation and plotting in Paraview
+// Define quantities for mesh adaptation and plotting in ParaView
   macro adaptu(u)[u, u#y, u#z], u#p//EOM
   macro adaptf(f)[f, f#y, f#z]//EOM
-// Name and order for real Paraview outputs
-  string ParaviewDataName = "velocity pressure";
-  string ParaviewDataNamef = "momentum";
-  int[int] ParaviewOrder = [1, 1];
-  int[int] ParaviewOrderf = [1];
-// Name and order for complex Paraview outputs
-  string ParaviewDataNamec = "velocity_r pressure_r velocity_i pressure_i";
-  string ParaviewDataNamefc = "momentum_r momentum_i";
-  int[int] ParaviewOrderc = [ParaviewOrder, ParaviewOrder];
-  int[int] ParaviewOrderfc = [ParaviewOrderf, ParaviewOrderf];
+// Names for ParaView outputs
+  string[int] ParaViewNames = ["velocity", "pressure"];
+  string[int] ParaViewNamesf = ["momentum"];
+// Initial conditions (if no file)
   // Initial conditions (if no file)
   macro InitialConditions()[1, 0, (params["S"]*((y<=1)*y*(2-y^2) + (y>1)/(y+(y==0)))), 0, 0]//EOM
 // Boundary labels

--- a/examples/douglas_etal_2021/README.md
+++ b/examples/douglas_etal_2021/README.md
@@ -103,7 +103,7 @@ ff-mpirun -np $nproc foldcompute.md -v 0 -dir $workdir -fi $B -fo swirljet100_B 
 ff-mpirun -np $nproc foldcompute.md -v 0 -dir $workdir -fi $F -fo swirljet100_F -param S -mo swirljet100_F -adaptto b -thetamax 1 -nf 0
 ```
 
-6. Adapt the mesh to the critical base/direct/adjoint solutions, save `.vtu` files for Paraview
+6. Adapt the mesh to the critical base/direct/adjoint solutions, save `.vtu` files for ParaView
 ```sh
 ff-mpirun -np $nproc foldcompute.md -v 0 -dir $workdir -fi swirljet100_B.fold -fo swirljet100_B -mo swirljet100_B -adaptto bda -param S -pv 1 -thetamax 1
 ff-mpirun -np $nproc foldcompute.md -v 0 -dir $workdir -fi swirljet100_F.fold -fo swirljet100_F -mo swirljet100_F -adaptto bda -param S -pv 1 -thetamax 1
@@ -132,7 +132,7 @@ ff-mpirun -np $nproc hopfcompute.md -v 0 -dir $workdir -fi swirljet1p8m1.mode -f
 ff-mpirun -np $nproc hopfcompute.md -v 0 -dir $workdir -fi swirljet1p8m2.mode -fo swirljetm2 -param 1/Re -nf 0
 ```
 
-11. Adapt the mesh to the critical base/direct/adjoint solutions, save `.vtu` files for Paraview
+11. Adapt the mesh to the critical base/direct/adjoint solutions, save `.vtu` files for ParaView
 ```sh
 ff-mpirun -np $nproc hopfcompute.md -v 0 -dir $workdir -fi swirljetm1.hopf -fo swirljetm1 -param 1/Re -mo swirljetm1 -adaptto bda -pv 1 -thetamax 1
 ff-mpirun -np $nproc hopfcompute.md -v 0 -dir $workdir -fi swirljetm2.hopf -fo swirljetm2 -param 1/Re -mo swirljetm2 -adaptto bda -pv 1 -thetamax 1

--- a/examples/douglas_etal_2021/settings_douglas_etal_2021.idp
+++ b/examples/douglas_etal_2021/settings_douglas_etal_2021.idp
@@ -21,21 +21,12 @@
   macro deff(f)[f, f#y, f#z]//EOM
   macro initf(i)[i, i, i]//EOM
   func Pkf = [P2, P2, P2];
-// Define quantities for mesh adaptation and plotting in Paraview
+// Define quantities for mesh adaptation and plotting in ParaView
   macro adaptu(u)[u, u#y, u#z], u#p//EOM
   macro adaptf(f)[f, f#y, f#z]//EOM
-// Name and order for real Paraview outputs
-  string ParaviewDataName = "velocity pressure";
-  string ParaviewDataNamef = "momentum";
-  int[int] ParaviewOrder = [1, 1];
-  int[int] ParaviewOrderf = [1];
-// Name and order for complex Paraview outputs
-  string ParaviewDataNamec = "velocity_r pressure_r velocity_i pressure_i";
-  string ParaviewDataNamefc = "momentum_r momentum_i";
-  int[int] ParaviewOrderc = [ParaviewOrder, ParaviewOrder];
-  int[int] ParaviewOrderfc = [ParaviewOrderf, ParaviewOrderf];
-  // Initial conditions (if no file)
-  macro InitialConditions()initu(0)//EOM
+// Names for ParaView outputs
+  string[int] ParaViewNames = ["velocity", "pressure"];
+  string[int] ParaViewNamesf = ["momentum"];
 // Boundary labels
   int BCnull = 0;
   int BCaxis = 1;

--- a/examples/douglas_etal_2022/README.md
+++ b/examples/douglas_etal_2022/README.md
@@ -104,7 +104,7 @@ ff-mpirun -np $nproc foldcompute.md -v 0 -dir $workdir -fi $B -fo annularjet100_
 ff-mpirun -np $nproc foldcompute.md -v 0 -dir $workdir -fi $F -fo annularjet100_F -param S -mo annularjet100_F -adaptto b -thetamax 1 -nf 0
 ```
 
-6. Adapt the mesh to the critical base/direct/adjoint solutions, save `.vtu` files for Paraview
+6. Adapt the mesh to the critical base/direct/adjoint solutions, save `.vtu` files for ParaView
 ```sh
 ff-mpirun -np $nproc foldcompute.md -v 0 -dir $workdir -fi annularjet100_B.fold -fo annularjet100_B -mo annularet100_B -adaptto bda -param S -pv 1 -thetamax 1
 ff-mpirun -np $nproc foldcompute.md -v 0 -dir $workdir -fi annularjet100_F.fold -fo annularjet100_F -mo annularjet100_F -adaptto bda -param S -pv 1 -thetamax 1

--- a/examples/douglas_etal_2022/settings_douglas_etal_2022.idp
+++ b/examples/douglas_etal_2022/settings_douglas_etal_2022.idp
@@ -21,21 +21,12 @@
   macro deff(f)[f, f#y, f#z]//EOM
   macro initf(i)[i, i, i]//EOM
   func Pkf = [P2, P2, P2];
-// Define quantities for mesh adaptation and plotting in Paraview
+// Define quantities for mesh adaptation and plotting in ParaView
   macro adaptu(u)[u, u#y, u#z], u#p//EOM
   macro adaptf(f)[f, f#y, f#z]//EOM
-// Name and order for real Paraview outputs
-  string ParaviewDataName = "velocity pressure";
-  string ParaviewDataNamef = "momentum";
-  int[int] ParaviewOrder = [1, 1];
-  int[int] ParaviewOrderf = [1];
-// Name and order for complex Paraview outputs
-  string ParaviewDataNamec = "velocity_r pressure_r velocity_i pressure_i";
-  string ParaviewDataNamefc = "momentum_r momentum_i";
-  int[int] ParaviewOrderc = [ParaviewOrder, ParaviewOrder];
-  int[int] ParaviewOrderfc = [ParaviewOrderf, ParaviewOrderf];
-  // Initial conditions (if no file)
-  macro InitialConditions()initu(0)//EOM
+// Names for ParaView outputs
+  string[int] ParaViewNames = ["velocity", "pressure"];
+  string[int] ParaViewNamesf = ["momentum"];
 // Boundary labels
   int BCnull = 0;
   int BCaxis = 1;

--- a/examples/douglas_etal_2023/settings_douglas_etal_2023.idp
+++ b/examples/douglas_etal_2023/settings_douglas_etal_2023.idp
@@ -25,21 +25,13 @@
   macro deff(f)[f,f#y,f#z]//EOM
   macro initf(i)[i, i, i]//EOM
   func Pkf = [P2, P2, P2];
-// Define quantities for mesh adaptation and plotting in Paraview
+// Define quantities for mesh adaptation and plotting in ParaView
   macro adaptu(u)[u, u#y, u#z], u#Y, u#T, u#p//EOM
   macro adaptf(f)[f, f#y, f#z] //EOM
-// Name and order for real Paraview outputs
-  string ParaviewDataName = "velocity species temperature pressure";
-  string ParaviewDataNamef = "momentum";
-  int[int] ParaviewOrder = [1, 1, 1, 1];
-  int[int] ParaviewOrderf = [1];
-// Name and order for complex Paraview outputs
-  string ParaviewDataNamec = "velocity_r species_r temperature_r pressure_r";
-  ParaviewDataNamec = ParaviewDataNamec + " velocity_i species_i temperature_i pressure_i";
-  string ParaviewDataNamefc = "momentum_r momentum_i";
-  int[int] ParaviewOrderc = [ParaviewOrder,ParaviewOrder];
-  int[int] ParaviewOrderfc = [ParaviewOrderf,ParaviewOrderf];
-  // Initial conditions (if no file)
+// Names for ParaView outputs
+  string[int] ParaViewNames = ["velocity", "species", "temperature", "pressure"];
+  string[int] ParaViewNamesf = ["momentum"];
+// Initial conditions (if no file)
   macro InitialConditions()[0, 0, 0, 1, 1, 0]//EOM
 // Boundary labels
   int BCnull = 0;

--- a/examples/douglas_jolivet_2026/settings_douglas_jolivet_2026_brusselator.idp
+++ b/examples/douglas_jolivet_2026/settings_douglas_jolivet_2026_brusselator.idp
@@ -22,9 +22,8 @@
   func Pk = [P2, P2];
 // Define quantities for mesh adaptation and plotting in ParaView
   macro adaptu(u)u, u#Y//EOM
-// Names for ParaView outputs
+// Names for ParaView output
   string[int] ParaViewNames = ["X", "Y"];
-  string[int] ParaViewNamesf = ParaViewNames;
 // Initial conditions (if no file)
   macro InitialConditions()[params["A"], params["B"]/params["A"]]//EOM
 // Boundary labels

--- a/examples/douglas_jolivet_2026/settings_douglas_jolivet_2026_brusselator.idp
+++ b/examples/douglas_jolivet_2026/settings_douglas_jolivet_2026_brusselator.idp
@@ -20,13 +20,8 @@
   macro defu(u)[u, u#Y]//EOM
   macro initu(i)[i, i]//EOM
   func Pk = [P2, P2];
-// Define forcing vector and FE space (for resolvent analysis)
-  macro deff(f)[f, f#Y]//EOM
-  macro initf(i)[i, i]//EOM
-  func Pkf = [P2, P2];
 // Define quantities for mesh adaptation and plotting in ParaView
   macro adaptu(u)u, u#Y//EOM
-  macro adaptf(f)f, f#Y//EOM
 // Names for ParaView outputs
   string[int] ParaViewNames = ["X", "Y"];
   string[int] ParaViewNamesf = ParaViewNames;

--- a/examples/douglas_jolivet_2026/settings_douglas_jolivet_2026_brusselator.idp
+++ b/examples/douglas_jolivet_2026/settings_douglas_jolivet_2026_brusselator.idp
@@ -24,20 +24,13 @@
   macro deff(f)[f, f#Y]//EOM
   macro initf(i)[i, i]//EOM
   func Pkf = [P2, P2];
-// Define quantities for mesh adaptation and plotting in Paraview
+// Define quantities for mesh adaptation and plotting in ParaView
   macro adaptu(u)u, u#Y//EOM
   macro adaptf(f)f, f#Y//EOM
-// Name and order for real Paraview outputs
-  string ParaviewDataName = "X Y";
-  string ParaviewDataNamef = ParaviewDataName;
-  int[int] ParaviewOrder = [1, 1];
-  int[int] ParaviewOrderf = ParaviewOrder;
-// Name and order for complex Paraview outputs
-  string ParaviewDataNamec = "X_r Y_r X_i Y_i";
-  string ParaviewDataNamefc = ParaviewDataNamec;
-  int[int] ParaviewOrderc = [ParaviewOrder, ParaviewOrder];
-  int[int] ParaviewOrderfc = ParaviewOrderc;
-  // Initial conditions (if no file)
+// Names for ParaView outputs
+  string[int] ParaViewNames = ["X", "Y"];
+  string[int] ParaViewNamesf = ParaViewNames;
+// Initial conditions (if no file)
   macro InitialConditions()[params["A"], params["B"]/params["A"]]//EOM
 // Boundary labels
   int BCnull = 0;

--- a/examples/douglas_jolivet_2026/settings_douglas_jolivet_2026_cylinder.idp
+++ b/examples/douglas_jolivet_2026/settings_douglas_jolivet_2026_cylinder.idp
@@ -23,22 +23,15 @@
   macro deff(f)[f, f#y, f#T, f#p]//EOM
   macro initf(i)[i, i, i, i]//EOM
   func Pkf = [P2, P2, P2, P1];
-// Define quantities for mesh adaptation and plotting in Paraview
+// Define quantities for mesh adaptation and plotting in ParaView
   macro adaptu(u)[u, u#y], u#T, u#p//EOM
   macro adaptf(f)[f, f#y], u#T, u#p//EOM
   macro paraviewu(u)[u, u#y, 0*u], u#T, u#p//EOM
   macro paraviewf(f)[f, f#y, 0*f], f#T, f#p//EOM
-// Name and order for real Paraview outputs
-  string ParaviewDataName = "velocity temperature pressure";
-  string ParaviewDataNamef = "momentum energy mass";
-  int[int] ParaviewOrder = [1, 1, 1];
-  int[int] ParaviewOrderf = [1, 1, 1];
-// Name and order for complex Paraview outputs
-  string ParaviewDataNamec = "velocity_r temperature_r pressure_r velocity_i temperature_i pressure_i";
-  string ParaviewDataNamefc = "momentum_r energy_r mass_r momentum_i energy_i mass_i";
-  int[int] ParaviewOrderc = [ParaviewOrder, ParaviewOrder];
-  int[int] ParaviewOrderfc = [ParaviewOrderf, ParaviewOrderf];
-  // Initial conditions (if no file)
+// Names for ParaView outputs
+  string[int] ParaViewNames = ["velocity", "temperature", "pressure"];
+  string[int] ParaViewNamesf = ["momentum", "energy", "mass"];
+// Initial conditions (if no file)
   macro InitialConditions()[1, 0, 1, 0]//EOM
 // Boundary labels
   int BCnull = 0;

--- a/examples/douglas_jolivet_2026/settings_douglas_jolivet_2026_structure.idp
+++ b/examples/douglas_jolivet_2026/settings_douglas_jolivet_2026_structure.idp
@@ -32,9 +32,8 @@
   int BCpsym = 9;
 // Define quantities for mesh adaptation and plotting in ParaView
   macro adaptu(u)[u, u#y, u#z]//EOM
-// Names for ParaView outputs
+// Names for ParaView output
   string[int] ParaViewNames = ["disp"];
-  string[int] ParaViewNamesf = ParaViewNames;
 // coordinate mapping macros ---------------------------------------------------
   macro coordinatetransform(U) x + real(U), y + real(U#y), z + real(U#z) // EOM
 // Define solution monitors to extract:

--- a/examples/douglas_jolivet_2026/settings_douglas_jolivet_2026_structure.idp
+++ b/examples/douglas_jolivet_2026/settings_douglas_jolivet_2026_structure.idp
@@ -30,18 +30,11 @@
   int BCxsym = 7;
   int BCysym = 8;
   int BCpsym = 9;
-// Define forcing vector and FE space (for resolvent analysis)
-  macro deff(f)[f, f#y, f#z]//EOM
-  macro initf(i)[i, i, i]//EOM
-  func Pkf = [P2, P2, P2];
 // Define quantities for mesh adaptation and plotting in ParaView
   macro adaptu(u)[u, u#y, u#z]//EOM
-  macro adaptf(f)[f, f#y, f#z]//EOM
 // Names for ParaView outputs
   string[int] ParaViewNames = ["disp"];
   string[int] ParaViewNamesf = ParaViewNames;
-// Initial conditions (if no file)
-  macro InitialConditions()initu(0)//EOM
 // coordinate mapping macros ---------------------------------------------------
   macro coordinatetransform(U) x + real(U), y + real(U#y), z + real(U#z) // EOM
 // Define solution monitors to extract:

--- a/examples/douglas_jolivet_2026/settings_douglas_jolivet_2026_structure.idp
+++ b/examples/douglas_jolivet_2026/settings_douglas_jolivet_2026_structure.idp
@@ -34,20 +34,13 @@
   macro deff(f)[f, f#y, f#z]//EOM
   macro initf(i)[i, i, i]//EOM
   func Pkf = [P2, P2, P2];
-// Define quantities for mesh adaptation and plotting in Paraview
+// Define quantities for mesh adaptation and plotting in ParaView
   macro adaptu(u)[u, u#y, u#z]//EOM
   macro adaptf(f)[f, f#y, f#z]//EOM
-// Name and order for real ParaView outputs
-  string ParaviewDataName = "disp";
-  string ParaviewDataNamef = ParaviewDataName;
-  int[int] ParaviewOrder = [1];
-  int[int] ParaviewOrderf = ParaviewOrder;
-// Name and order for complex Paraview outputs
-  string ParaviewDataNamec = ParaviewDataName + "_r " + ParaviewDataName + "_i";
-  string ParaviewDataNamefc = ParaviewDataNamec;
-  int[int] ParaviewOrderc = [ParaviewOrder, ParaviewOrder];
-  int[int] ParaviewOrderfc = ParaviewOrderc;
-  // Initial conditions (if no file)
+// Names for ParaView outputs
+  string[int] ParaViewNames = ["disp"];
+  string[int] ParaViewNamesf = ParaViewNames;
+// Initial conditions (if no file)
   macro InitialConditions()initu(0)//EOM
 // coordinate mapping macros ---------------------------------------------------
   macro coordinatetransform(U) x + real(U), y + real(U#y), z + real(U#z) // EOM

--- a/examples/fani_etal_2018/README.md
+++ b/examples/fani_etal_2018/README.md
@@ -118,7 +118,7 @@ NOTE: Here, the `-sym` argument specifies the asymmetric (1) or symmetric (0) re
 ff-mpirun -np $nproc hopfcompute.md -v 0 -dir $workdir -fi cylinder50.mode -fo cylinder -param 1/Re -nf 0
 ```
 
-3. Adapt the mesh to the critical solution, save `.vtu` files for Paraview
+3. Adapt the mesh to the critical solution, save `.vtu` files for ParaView
 ```sh
 ff-mpirun -np $nproc hopfcompute.md -v 0 -dir $workdir -fi cylinder.hopf -fo cylinder -mo cylinderhopf -adaptto bda -param 1/Re -thetamax 5 -pv 1
 ```

--- a/examples/fani_etal_2018/settings_fani_etal_2018.idp
+++ b/examples/fani_etal_2018/settings_fani_etal_2018.idp
@@ -23,20 +23,15 @@
   macro deff(f)[f, f#y, f#T, f#p]//EOM
   macro initf(i)[i, i, i, i]//EOM
   func Pkf = [P2, P2, P2, P1];
-// Define quantities for mesh adaptation and plotting in Paraview
+// Define quantities for mesh adaptation and plotting in ParaView
   macro adaptu(u)[u, u#y], u#T, u#p//EOM
   macro adaptf(f)[f, f#y], f#T, f#p//EOM
-// Name and order for real Paraview outputs
-  string ParaviewDataName = "velocity temperature pressure";
-  string ParaviewDataNamef = "momentum energy mass";
-  int[int] ParaviewOrder = [1, 1, 1, 1];
-  int[int] ParaviewOrderf = [1, 1, 1];
-// Name and order for complex Paraview outputs
-  string ParaviewDataNamec = "velocity_r temperature_r pressure_r velocity_i temperature_i pressure_i";
-  string ParaviewDataNamefc = "momentum_r energy_r mass_r momentum_i energy_i mass_i";
-  int[int] ParaviewOrderc = [ParaviewOrder, ParaviewOrder];
-  int[int] ParaviewOrderfc = [ParaviewOrderf, ParaviewOrderf];
-  // Initial conditions (if no file)
+  macro paraviewu(u)[u, u#y, 0*u], u#T, u#p//EOM
+  macro paraviewf(f)[f, f#y, 0*f] f#T, f#p//EOM
+// Names for ParaView outputs
+  string[int] ParaViewNames = ["velocity", "temperature", "pressure"];
+  string[int] ParaViewNamesf = ["momentum", "energy", "mass"];
+// Initial conditions (if no file)
   macro InitialConditions()[1, 0, 1, 0]//EOM
 // Boundary labels
   int BCnull = 0;

--- a/examples/garnaud_2012/README.md
+++ b/examples/garnaud_2012/README.md
@@ -82,7 +82,7 @@ ff-mpirun -np $nproc basecontinue.md -v 0 -dir $workdir -fi jet.base -fo jet -pa
 ff-mpirun -np $nproc basecompute.md -v 0 -dir $workdir -fi jet_15.base -fo jet1000 -1/Re 0.001
 ```
 
-4. Adapt mesh to $Re=1000$ solution and recompute base state, save `.vtu` file for Paraview
+4. Adapt mesh to $Re=1000$ solution and recompute base state, save `.vtu` file for ParaView
 ```sh
 ff-mpirun -np $nproc basecompute.md -v 0 -dir $workdir -fi jet1000.base -fo jet1000adapt -mo jet1000adapt -pv 1
 ```
@@ -92,7 +92,7 @@ ff-mpirun -np $nproc basecompute.md -v 0 -dir $workdir -fi jet1000.base -fo jet1
 ```sh
 ff-mpirun -np $nproc rslvcompute.md -v 0 -dir $workdir -fi jet1000adapt.base -so jet1000adapt -omega 0.314159 -omegaf 3.14159 -nomega 10
 ```
-2. Compute forcing/response modes at $St=[0.1, 0.48, 0.64, 0.95]$, save `.vtu` files for Paraview
+2. Compute forcing/response modes at $St=[0.1, 0.48, 0.64, 0.95]$, save `.vtu` files for ParaView
 ```sh
 ff-mpirun -np $nproc rslvcompute.md -v 0 -dir $workdir -fi jet1000adapt.base -fo jet1000_St0p1 -omega 0.314159 -pv 1
 ff-mpirun -np $nproc rslvcompute.md -v 0 -dir $workdir -fi jet1000adapt.base -fo jet1000_St0p48 -omega 1.50796 -pv 1

--- a/examples/garnaud_2012/settings_garnaud_2012.idp
+++ b/examples/garnaud_2012/settings_garnaud_2012.idp
@@ -21,21 +21,14 @@
   macro deff(f)[f, f#y]//EOM
   macro initf(i)[i, i]//EOM
   func Pkf = [P2, P2];
-// Define quantities for mesh adaptation and plotting in Paraview
+// Define quantities for mesh adaptation and plotting in ParaView
   macro adaptu(u)[u, u#y], u#p//EOM
   macro adaptf(f)[f, f#y] //EOM
-// Name and order for real Paraview outputs
-  string ParaviewDataName = "velocity pressure";
-  string ParaviewDataNamef = "momentum";
-  int[int] ParaviewOrder = [1, 1];
-  int[int] ParaviewOrderf = [1];
-// Name and order for complex Paraview outputs
-  string ParaviewDataNamec = "velocity_r pressure_r velocity_i pressure_i";
-  string ParaviewDataNamefc = "momentum_r momentum_i";
-  int[int] ParaviewOrderc = [ParaviewOrder, ParaviewOrder];
-  int[int] ParaviewOrderfc = [ParaviewOrderf, ParaviewOrderf];
-  // Initial conditions (if no file)
-  macro InitialConditions()initu(0)//EOM
+  macro paraviewu(u)[u, u#y, 0*u], u#p//EOM
+  macro paraviewf(f)[f, f#y, 0*f] //EOM
+// Names for ParaView outputs
+  string[int] ParaViewNames = ["velocity", "pressure"];
+  string[int] ParaViewNamesf = ["momentum"];
 // Boundary labels
   int BCnull = 0;
   int BCaxis = 1;

--- a/examples/marquet_larsson_2015/settings_marquet_larsson_2015.idp
+++ b/examples/marquet_larsson_2015/settings_marquet_larsson_2015.idp
@@ -22,20 +22,13 @@
   macro deff(f)[f, f#y, f#z]//EOM
   macro initf(i)[i, i, i]//EOM
   func Pkf = [P2, P2, P2];
-// Define quantities for mesh adaptation and plotting in Paraview
+// Define quantities for mesh adaptation and plotting in ParaView
   macro adaptu(u)[u, u#y, u#z], u#p//EOM
   macro adaptf(f)[f, f#y, f#z]//EOM
-// Name and order for real Paraview outputs
-  string ParaviewDataName = "velocity pressure";
-  string ParaviewDataNamef = "momentum";
-  int[int] ParaviewOrder = [1, 1];
-  int[int] ParaviewOrderf = [1];
-// Name and order for complex Paraview outputs
-  string ParaviewDataNamec = "velocity_r pressure_r velocity_i pressure_i";
-  string ParaviewDataNamefc = "momentum_r momentum_i";
-  int[int] ParaviewOrderc = [ParaviewOrder, ParaviewOrder];
-  int[int] ParaviewOrderfc = [ParaviewOrderf, ParaviewOrderf];
-  // Initial conditions (if no file)
+// Names for ParaView outputs
+  string[int] ParaViewNames = ["velocity", "pressure"];
+  string[int] ParaViewNamesf = ["momentum"];
+// Initial conditions (if no file)
   macro InitialConditions()[1, 0, 0, 0]//EOM
 // Boundary labels
   int BCnull = 0;

--- a/examples/meliga_etal_2012/settings_meliga_etal_2012.idp
+++ b/examples/meliga_etal_2012/settings_meliga_etal_2012.idp
@@ -21,20 +21,13 @@
   macro deff(f)[f, f#y, f#z]//EOM
   macro initf(i)[i, i, i]//EOM
   func Pkf = [P2, P2, P2];
-// Define quantities for mesh adaptation and plotting in Paraview
+// Define quantities for mesh adaptation and plotting in ParaView
   macro adaptu(u)[u, u#y, u#z], u#p//EOM
   macro adaptf(f)[f, f#y, f#z]//EOM
-// Name and order for real Paraview outputs
-  string ParaviewDataName = "velocity pressure";
-  string ParaviewDataNamef = "momentum";
-  int[int] ParaviewOrder = [1, 1];
-  int[int] ParaviewOrderf = [1];
-// Name and order for complex Paraview outputs
-  string ParaviewDataNamec = "velocity_r pressure_r velocity_i pressure_i";
-  string ParaviewDataNamefc = "momentum_r momentum_i";
-  int[int] ParaviewOrderc = [ParaviewOrder, ParaviewOrder];
-  int[int] ParaviewOrderfc = [ParaviewOrderf, ParaviewOrderf];
-  // Initial conditions (if no file)
+// Names for ParaView outputs
+  string[int] ParaViewNames = ["velocity", "pressure"];
+  string[int] ParaViewNamesf = ["momentum"];
+// Initial conditions (if no file)
   macro InitialConditions()[1, 0, (params["S"]*((y<=1)*y*(2-y^2) + (y>1)/(y+(y==0)))), 0]//EOM
 // Boundary labels
   int BCnull = 0;

--- a/examples/moreno-boza_etal_2018/settings_moreno-boza_etal_2018.idp
+++ b/examples/moreno-boza_etal_2018/settings_moreno-boza_etal_2018.idp
@@ -28,23 +28,15 @@
   macro deff(f)[f, f#y]//EOM
   macro initf(i)[i, i]//EOM
   func Pkf = [P2, P2];
-// Define quantities for mesh adaptation and plotting in Paraview
+// Define quantities for mesh adaptation and plotting in ParaView
   macro Zfrom(U) ( Zs*min(real(U#Zt)/Zts, 1.0) + max(real(U#Zt) - Zts, 0.0)/(1.0 - Zts)*(1.0 - Zs) ) // EOM
   macro Tfrom(U) ( 1.0 + (params["TB"] - 1.0 - params["qoS"])*U#H + params["qoS"]*min(1.0, real(U#Zt)/Zts) ) // EOM
   macro adaptu(u)[u, u#y], u#Zt, u#H, Tfrom(u), Zfrom(u), u#p //EOM
   macro adaptf(f)[f, f#y] //EOM
-// Name and order for real Paraview outputs  
-  macro paraviewu(u)[u, u#y, u*0], u#Zt, u#H, Tfrom(u), Zfrom(u), u#p //EOM
-  string ParaviewDataName = "velocity Ztilde enthalpy temperature Z pressure";
-  string ParaviewDataNamef = "momentum";
-  int[int] ParaviewOrder = [1, 1, 1, 1, 1, 1];
-  int[int] ParaviewOrderf = [1];
-// Name and order for complex Paraview outputs
-  string ParaviewDataNamec = "velocity_r Ztilde_r enthalpy_r temperature_r Z_r pressure_r velocity_i Ztilde_i enthalpy_i temperature_i Z_i pressure_i";
-  string ParaviewDataNamefc = "momentum_r momentum_i";
-  int[int] ParaviewOrderc = [ParaviewOrder, ParaviewOrder];
-  int[int] ParaviewOrderfc = [ParaviewOrderf, ParaviewOrderf];
-  // Initial conditions (if no file)
+// Names for ParaView outputs
+  string[int] ParaViewNames = ["velocity", "pressure"];
+  string[int] ParaViewNamesf = ["momentum"];
+// Initial conditions (if no file)
   macro InitialConditions()[0, 0, 0, 1, 0, 0]//EOM
 // Boundary labels
   int BCnull = 0;

--- a/examples/moulin_etal_2019/settings_moulin_etal_2019.idp
+++ b/examples/moulin_etal_2019/settings_moulin_etal_2019.idp
@@ -22,20 +22,13 @@
   macro deff(f)[f, f#y, f#z]//EOM
   macro initf(i)[i, i, i]//EOM
   func Pkf = [P2, P2, P2];
-// Define quantities for mesh adaptation and plotting in Paraview
+// Define quantities for mesh adaptation and plotting in ParaView
   macro adaptu(u)[u, u#y, u#z], u#p//EOM
   macro adaptf(f)[f, f#y, f#z]//EOM
-// Name and order for real Paraview outputs
-  string ParaviewDataName = "velocity pressure";
-  string ParaviewDataNamef = "momentum";
-  int[int] ParaviewOrder = [1, 1];
-  int[int] ParaviewOrderf = [1];
-// Name and order for complex Paraview outputs
-  string ParaviewDataNamec = "velocity_r pressure_r velocity_i pressure_i";
-  string ParaviewDataNamefc = "momentum_r momentum_i";
-  int[int] ParaviewOrderc = [ParaviewOrder, ParaviewOrder];
-  int[int] ParaviewOrderfc = [ParaviewOrderf, ParaviewOrderf];
-  // Initial conditions (if no file)
+// Names for ParaView outputs
+  string[int] ParaViewNames = ["velocity", "pressure"];
+  string[int] ParaViewNamesf = ["momentum"];
+// Initial conditions (if no file)
   macro InitialConditions()[1, 0, 0, 0]//EOM
 // Boundary labels
   int BCnull = 0;

--- a/examples/pralits_etal_2010/README.md
+++ b/examples/pralits_etal_2010/README.md
@@ -97,7 +97,7 @@ ff-mpirun -np $nproc foldcompute.md -v 0 -dir $workdir -fi ${foldguesslist[0]} -
 ff-mpirun -np $nproc foldcompute.md -v 0 -dir $workdir -fi ${foldguesslist[1]} -fo cylinder100_F -param alpha -nf 0
 ```
 
-6. Adapt the mesh to the critical base/direct/adjoint solutions, save `.vtu` files for Paraview
+6. Adapt the mesh to the critical base/direct/adjoint solutions, save `.vtu` files for ParaView
 ```sh
 ff-mpirun -np $nproc foldcompute.md -v 0 -dir $workdir -fi cylinder100_B.fold -fo cylinder100_B -mo cylinder100_B -adaptto bda -param alpha -pv 1 -thetamax 1 -hmin 5e-3 -dmax 1 -err 0.005
 ff-mpirun -np $nproc foldcompute.md -v 0 -dir $workdir -fi cylinder100_F.fold -fo cylinder100_F -mo cylinder100_F -adaptto bda -param alpha -pv 1 -thetamax 1 -hmin 5e-3 -dmax 1 -err 0.005
@@ -126,7 +126,7 @@ ff-mpirun -np $nproc hopfcompute.md -v 0 -dir $workdir -fi cylindermode1.mode -f
 ff-mpirun -np $nproc hopfcompute.md -v 0 -dir $workdir -fi cylindermode2.mode -fo cylindermode2 -param alpha -nf 0
 ```
 
-11. Adapt the mesh to the critical solutions, save `.vtu` files for Paraview
+11. Adapt the mesh to the critical solutions, save `.vtu` files for ParaView
 ```sh
 ff-mpirun -np $nproc hopfcompute.md -v 0 -dir $workdir -fi cylindermode1.hopf -fo cylindermode1 -mo cylindermode1hopf -adaptto bda -param 1/Re -thetamax 1 -hmin 5e-3 -dmax 1 -err 0.005 -pv 1
 ff-mpirun -np $nproc hopfcompute.md -v 0 -dir $workdir -fi cylindermode2.hopf -fo cylindermode2 -mo cylindermode2hopf -adaptto bda -param alpha -thetamax 1 -hmin 5e-3 -dmax 1 -err 0.005 -pv 1

--- a/examples/pralits_etal_2010/settings_pralits_etal_2010.idp
+++ b/examples/pralits_etal_2010/settings_pralits_etal_2010.idp
@@ -21,20 +21,15 @@
   macro deff(f)[f, f#y]//EOM
   macro initf(i)[i, i]//EOM
   func Pkf = [P2, P2];
-// Define quantities for mesh adaptation and plotting in Paraview
+// Define quantities for mesh adaptation and plotting in ParaView
   macro adaptu(u)[u, u#y], u#p//EOM
   macro adaptf(f)[f, f#y] //EOM
-// Name and order for real Paraview outputs
-  string ParaviewDataName = "velocity pressure";
-  string ParaviewDataNamef = "momentum";
-  int[int] ParaviewOrder = [1, 1];
-  int[int] ParaviewOrderf = [1];
-// Name and order for complex Paraview outputs
-  string ParaviewDataNamec = "velocity_r pressure_r velocity_i pressure_i";
-  string ParaviewDataNamefc = "momentum_r momentum_i";
-  int[int] ParaviewOrderc = [ParaviewOrder, ParaviewOrder];
-  int[int] ParaviewOrderfc = [ParaviewOrderf, ParaviewOrderf];
-  // Initial conditions (if no file)
+  macro paraviewu(u)[u, u#y, 0*u], u#p//EOM
+  macro paraviewf(f)[f, f#y, 0*f] //EOM
+// Names for ParaView outputs
+  string[int] ParaViewNames = ["velocity", "pressure"];
+  string[int] ParaViewNamesf = ["momentum"];
+// Initial conditions (if no file)
   macro InitialConditions()[1, 0, 0]//EOM
 // Boundary labels
   int BCnull = 0;

--- a/examples/sipp_lebedev_2007/README.md
+++ b/examples/sipp_lebedev_2007/README.md
@@ -107,7 +107,7 @@ ff-mpirun -np $nproc hopfcompute.md -v 0 -dir $workdir -fi cylinder50.mode -fo c
 ff-mpirun -np $nproc hopfcompute.md -v 0 -dir $workdir -fi cavity4000.mode -fo cavity -param 1/Re -nf 0
 ```
 
-3. Adapt the mesh to the critical solution, save `.vtu` files for Paraview
+3. Adapt the mesh to the critical solution, save `.vtu` files for ParaView
 ```sh
 ff-mpirun -np $nproc hopfcompute.md -v 0 -dir $workdir -fi cylinder.hopf -fo cylinderadapt -mo cylinderhopf -adaptto bda -param 1/Re -thetamax 5 -pv 1 -wnl 1 
 ff-mpirun -np $nproc hopfcompute.md -v 0 -dir $workdir -fi cavity.hopf -fo cavityadapt -mo cavityhopf -adaptto bda -param 1/Re -pv 1 -wnl 1
@@ -131,7 +131,7 @@ NOTE: Sipp & Lebedev do not perform harmonic balance analysis. See Fabre et al.,
 
 
 ### Time-domain nonlinear simulation
-1. Compute time series over first 10 time units for cavity case after step increase in Reynolds number, adapt mesh to solution, export files to Paraview. 
+1. Compute time series over first 10 time units for cavity case after step increase in Reynolds number, adapt mesh to solution, export files to ParaView. 
 ```sh
 ff-mpirun -np $nproc tdnscompute.md -v 0 -dir $workdir -fi cavity4000.base -fo cavity -1/Re 0.0002 -tsdt 0.01 -mo cavitytimeseries -scount 5 -maxcount 1000 -pv 1
 ```

--- a/examples/sipp_lebedev_2007/settings_sipp_lebedev_2007.idp
+++ b/examples/sipp_lebedev_2007/settings_sipp_lebedev_2007.idp
@@ -21,20 +21,15 @@
   macro deff(f)[f, f#y]//EOM
   macro initf(i)[i, i]//EOM
   func Pkf = [P2, P2];
-// Define quantities for mesh adaptation and plotting in Paraview
+// Define quantities for mesh adaptation and plotting in ParaView
   macro adaptu(u)[u, u#y], u#p//EOM
   macro adaptf(f)[f, f#y] //EOM
-// Name and order for real Paraview outputs
-  string ParaviewDataName = "velocity pressure";
-  string ParaviewDataNamef = "momentum";
-  int[int] ParaviewOrder = [1, 1];
-  int[int] ParaviewOrderf = [1];
-// Name and order for complex Paraview outputs
-  string ParaviewDataNamec = "velocity_r pressure_r velocity_i pressure_i";
-  string ParaviewDataNamefc = "momentum_r momentum_i";
-  int[int] ParaviewOrderc = [ParaviewOrder, ParaviewOrder];
-  int[int] ParaviewOrderfc = [ParaviewOrderf, ParaviewOrderf];
-  // Initial conditions (if no file)
+  macro paraviewu(u)[u, u#y, 0*u], u#p//EOM
+  macro paraviewf(f)[f, f#y, 0*f] //EOM
+// Names for ParaView outputs
+  string[int] ParaViewNames = ["velocity", "pressure"];
+  string[int] ParaViewNamesf = ["momentum"];
+// Initial conditions (if no file)
   macro InitialConditions()[1, 0, 0]//EOM
 // Boundary labels
   int BCnull = 0;

--- a/examples/sipp_marquet_2013/settings_sipp_marquet_2013.idp
+++ b/examples/sipp_marquet_2013/settings_sipp_marquet_2013.idp
@@ -26,20 +26,13 @@
   macro Blasiustheta() ( 0.664*sqrt(params["1/Re"]) ) // EOM // Blasius BL momentum thickness
   macro adaptu(u)[u, u#y], u#p, (0.6+x)*exp(-(y/Blasiusdelta)^2)*sin(y/Blasiustheta), (0.6+x)*exp(-(y/Blasiusdelta)^2)*cos(y/Blasiustheta)//
   macro adaptf(f)[f, f#y] //EOM
-// Define quantities for plotting in Paraview
+// Define quantities for plotting in ParaView
   macro paraviewu(u)[u, u#y, 0*u#y], u#p//EOM
   macro paraviewf(f)[f, f#y, 0*f#y] //EOM
-// Name and order for real Paraview outputs
-  string ParaviewDataName = "velocity pressure";
-  string ParaviewDataNamef = "momentum";
-  int[int] ParaviewOrder = [1, 1];
-  int[int] ParaviewOrderf = [1];
-// Name and order for complex Paraview outputs
-  string ParaviewDataNamec = "velocity_r pressure_r velocity_i pressure_i";
-  string ParaviewDataNamefc = "momentum_r momentum_i";
-  int[int] ParaviewOrderc = [ParaviewOrder, ParaviewOrder];
-  int[int] ParaviewOrderfc = [ParaviewOrderf, ParaviewOrderf];
-  // Initial conditions (if no file)
+// Names for ParaView outputs
+  string[int] ParaViewNames = ["velocity", "pressure"];
+  string[int] ParaViewNamesf = ["momentum"];
+// Initial conditions (if no file)
   macro InitialConditions()[1, 0, 0]//EOM
 // Boundary labels
   int BCnull = 0;

--- a/examples/wang_etal_2024/settings_wang_etal_2024.idp
+++ b/examples/wang_etal_2024/settings_wang_etal_2024.idp
@@ -25,21 +25,15 @@
   macro deff(f)[f, f#y]//EOM
   macro initf(i)[i, i]//EOM
   func Pkf = [P2, P2];
-// Define quantities for mesh adaptation and plotting in Paraview
+// Define quantities for mesh adaptation and plotting in ParaView
   macro adaptu(u)[u, u#y], u#Y, u#T, u#p//EOM
   macro adaptf(f)[f, f#y] //EOM
-// Name and order for real Paraview outputs
-  string ParaviewDataName = "velocity species temperature pressure";
-  string ParaviewDataNamef = "momentum";
-  int[int] ParaviewOrder = [1, 1, 1, 1];
-  int[int] ParaviewOrderf = [1];
-// Name and order for complex Paraview outputs
-  string ParaviewDataNamec = "velocity_r species_r temperature_r pressure_r";
-  ParaviewDataNamec = ParaviewDataNamec + " velocity_i species_i temperature_i pressure_i";
-  string ParaviewDataNamefc = "momentum_r momentum_i";
-  int[int] ParaviewOrderc = [ParaviewOrder,ParaviewOrder];
-  int[int] ParaviewOrderfc = [ParaviewOrderf,ParaviewOrderf];
-  // Initial conditions (if no file)
+  macro paraviewu(u)[u, u#y, 0*u], u#Y, u#T, u#p//EOM
+  macro paraviewf(f)[f, f#y, 0*f] //EOM
+// Names for ParaView outputs
+  string[int] ParaViewNames = ["velocity", "species", "temperature", "pressure"];
+  string[int] ParaViewNamesf = ["momentum"];
+// Initial conditions (if no file)
   macro InitialConditions()[0, 0, 0.04256, 300, 0]//EOM
 // Boundary labels
   int BCnull = 0;

--- a/macros_bifbox.idp
+++ b/macros_bifbox.idp
@@ -20,7 +20,10 @@ ENDIFMACRO
 IFMACRO(!paraviewf)
   macro paraviewf(f) adaptf(f) // EOM
 ENDIFMACRO
-
+// If settings files does not define InitialConditions
+IFMACRO(!InitialConditions)
+  macro InitialConditions()initu(0)//EOM
+ENDIFMACRO
 // If settings file does not define a coordinate transform.
 IFMACRO(!coordinatetransform)
   IFMACRO(dimension,2)
@@ -30,6 +33,33 @@ IFMACRO(!coordinatetransform)
     macro coordinatetransform(U) x, y, z // EOM
   ENDIFMACRO
 ENDIFMACRO
+// Define ParaviewOrder to export real data at vertices
+int[int] ParaviewOrder(ParaViewNames.n);
+ParaviewOrder = 1;
+int[int] ParaviewOrderf(ParaViewNamesf.n);
+ParaviewOrderf = 1;
+// Define ParaviewOrderc to export complex data at vertices
+int[int] ParaviewOrderc  = [ParaviewOrder,  ParaviewOrder];
+int[int] ParaviewOrderfc = [ParaviewOrderf, ParaviewOrderf];
+// Convert ParaViewNames into the strings: ParaviewDataName, ParaviewDataNamec
+string ParaviewDataName="", ParaviewDataNamec="";
+for (int i=0; i<ParaViewNames.n; i++) {
+    if (i) { ParaviewDataName = ParaviewDataName + " "; ParaviewDataNamec = ParaviewDataNamec + " "; }
+    ParaviewDataName  = ParaviewDataName + ParaViewNames[i];
+    ParaviewDataNamec = ParaviewDataNamec + ParaViewNames[i] + "_r";
+}
+for (int i=0; i<ParaViewNames.n; i++)
+    ParaviewDataNamec = ParaviewDataNamec + " " + ParaViewNames[i] + "_i";
+// Convert ParaViewNamesf into the strings: ParaviewDataNamef, ParaviewDataNamefc
+string ParaviewDataNamef="", ParaviewDataNamefc="";
+for (int i=0; i<ParaViewNamesf.n; i++) {
+    if (i) { ParaviewDataNamef = ParaviewDataNamef + " "; ParaviewDataNamefc = ParaviewDataNamefc + " "; }
+    ParaviewDataNamef  = ParaviewDataNamef + ParaViewNamesf[i];
+    ParaviewDataNamefc = ParaviewDataNamefc + ParaViewNamesf[i] + "_r";
+}
+for (int i=0; i<ParaViewNamesf.n; i++)
+    ParaviewDataNamefc = ParaviewDataNamefc + " " + ParaViewNamesf[i] + "_i";
+
 // Parse mesh or solution filename
 func string parsefilename(string & filename, string & fileroot){
   string fileext;

--- a/macros_bifbox.idp
+++ b/macros_bifbox.idp
@@ -9,11 +9,11 @@
 cout.precision(12);
 string workdir = getARGV("-dir","./data/"); // set working directory
 if (workdir(workdir.length-1:workdir.length-1) != "/") workdir = workdir + "/";
-int paraviewflag = getARGV("-pv", 0); // indicate whether solution is saved for Paraview
-// paraviewflag <= 0: don't save data in Paraview format (only in FF format)
-// paraviewflag == 1: save in Paraview format on current mesh
-// paraviewflag == 2, 3, ...: save in Paraview format on 2x, 3x, ... refined mesh using meshsplit
-// If settings file does not define a paraview output format
+int paraviewflag = getARGV("-pv", 0); // indicate whether solution is saved for ParaView
+// paraviewflag <= 0: don't save data in ParaView format (only in FF format)
+// paraviewflag == 1: save in ParaView format on current mesh
+// paraviewflag == 2, 3, ...: save in ParaView format on 2x, 3x, ... refined mesh using meshsplit
+// If settings file does not define a ParaView output format
 IFMACRO(!paraviewu)
   macro paraviewu(u) adaptu(u) // EOM
 ENDIFMACRO
@@ -33,32 +33,32 @@ IFMACRO(!coordinatetransform)
     macro coordinatetransform(U) x, y, z // EOM
   ENDIFMACRO
 ENDIFMACRO
-// Define ParaviewOrder to export real data at vertices
-int[int] ParaviewOrder(ParaViewNames.n);
-ParaviewOrder = 1;
-int[int] ParaviewOrderf(ParaViewNamesf.n);
-ParaviewOrderf = 1;
-// Define ParaviewOrderc to export complex data at vertices
-int[int] ParaviewOrderc  = [ParaviewOrder,  ParaviewOrder];
-int[int] ParaviewOrderfc = [ParaviewOrderf, ParaviewOrderf];
-// Convert ParaViewNames into the strings: ParaviewDataName, ParaviewDataNamec
-string ParaviewDataName="", ParaviewDataNamec="";
+// Define ParaViewOrder to export real data at vertices
+int[int] ParaViewOrder(ParaViewNames.n);
+ParaViewOrder = 1;
+int[int] ParaViewOrderf(ParaViewNamesf.n);
+ParaViewOrderf = 1;
+// Define ParaViewOrderc to export complex data at vertices
+int[int] ParaViewOrderc  = [ParaViewOrder,  ParaViewOrder];
+int[int] ParaViewOrderfc = [ParaViewOrderf, ParaViewOrderf];
+// Convert ParaViewNames into the strings: ParaViewDataName, ParaViewDataNamec
+string ParaViewDataName="", ParaViewDataNamec="";
 for (int i=0; i<ParaViewNames.n; i++) {
-    if (i) { ParaviewDataName = ParaviewDataName + " "; ParaviewDataNamec = ParaviewDataNamec + " "; }
-    ParaviewDataName  = ParaviewDataName + ParaViewNames[i];
-    ParaviewDataNamec = ParaviewDataNamec + ParaViewNames[i] + "_r";
+    if (i) { ParaViewDataName = ParaViewDataName + " "; ParaViewDataNamec = ParaViewDataNamec + " "; }
+    ParaViewDataName  = ParaViewDataName + ParaViewNames[i];
+    ParaViewDataNamec = ParaViewDataNamec + ParaViewNames[i] + "_r";
 }
 for (int i=0; i<ParaViewNames.n; i++)
-    ParaviewDataNamec = ParaviewDataNamec + " " + ParaViewNames[i] + "_i";
-// Convert ParaViewNamesf into the strings: ParaviewDataNamef, ParaviewDataNamefc
-string ParaviewDataNamef="", ParaviewDataNamefc="";
+    ParaViewDataNamec = ParaViewDataNamec + " " + ParaViewNames[i] + "_i";
+// Convert ParaViewNamesf into the strings: ParaViewDataNamef, ParaViewDataNamefc
+string ParaViewDataNamef="", ParaViewDataNamefc="";
 for (int i=0; i<ParaViewNamesf.n; i++) {
-    if (i) { ParaviewDataNamef = ParaviewDataNamef + " "; ParaviewDataNamefc = ParaviewDataNamefc + " "; }
-    ParaviewDataNamef  = ParaviewDataNamef + ParaViewNamesf[i];
-    ParaviewDataNamefc = ParaviewDataNamefc + ParaViewNamesf[i] + "_r";
+    if (i) { ParaViewDataNamef = ParaViewDataNamef + " "; ParaViewDataNamefc = ParaViewDataNamefc + " "; }
+    ParaViewDataNamef  = ParaViewDataNamef + ParaViewNamesf[i];
+    ParaViewDataNamefc = ParaViewDataNamefc + ParaViewNamesf[i] + "_r";
 }
 for (int i=0; i<ParaViewNamesf.n; i++)
-    ParaviewDataNamefc = ParaviewDataNamefc + " " + ParaViewNamesf[i] + "_i";
+    ParaViewDataNamefc = ParaViewDataNamefc + " " + ParaViewNamesf[i] + "_i";
 
 // Parse mesh or solution filename
 func string parsefilename(string & filename, string & fileroot){
@@ -1253,7 +1253,7 @@ macro savebase(basefileout, statsfile, meshfile, saveflag, monitorflag){
         fespace XMhgpv(Thgpv, Pk);
         XMhgpv defu(ugr);
         ugr[] = qpv;
-        savevtk(workdir + basefileout + "_base.vtu", Thgpv, paraviewu(ugr), dataname = ParaviewDataName, order = ParaviewOrder);
+        savevtk(workdir + basefileout + "_base.vtu", Thgpv, paraviewu(ugr), dataname = ParaViewDataName, order = ParaViewOrder);
       }
     }
   }
@@ -1334,7 +1334,7 @@ macro savemode(modefileout, statsfile, basefile, meshfile, evecs, evals, sym, sa
           XMhgpv defu(ugr), defu(ugi);
           ugr[] = qpv.re;
           ugi[] = qpv.im;
-          savevtk(workdir + modefileout0 + "_mode.vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaviewDataNamec, order = ParaviewOrderc);
+          savevtk(workdir + modefileout0 + "_mode.vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaViewDataNamec, order = ParaViewOrderc);
         }
       }
     }
@@ -1422,7 +1422,7 @@ macro saveresp(respfileout, statsfile, basefile, meshfile, sym, omega, saveflag,
         XMhgpv defu(ugr), defu(ugi);
         ugr[] = qpv.re;
         ugi[] = qpv.im;
-        savevtk(workdir + respfileout + "_resp.vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaviewDataNamec, order = ParaviewOrderc);
+        savevtk(workdir + respfileout + "_resp.vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaViewDataNamec, order = ParaViewOrderc);
       }
     }
   }
@@ -1513,12 +1513,12 @@ macro saverslv(rslvfileout, statsfile, basefile, meshfile, fvecs, uvecs, gains, 
           Xhgpv deff(fgr), deff(fgi);
           fgr[] = fpv.re;
           fgi[] = fpv.im;
-          savevtk(workdir + fileout + "_rslv_forcing.vtu", Thgpv, paraviewf(fgr), paraviewf(fgi), dataname = ParaviewDataNamefc, order = ParaviewOrderfc);
+          savevtk(workdir + fileout + "_rslv_forcing.vtu", Thgpv, paraviewf(fgr), paraviewf(fgi), dataname = ParaViewDataNamefc, order = ParaViewOrderfc);
           fespace XMhgpv(Thgpv, Pk);
           XMhgpv defu(ugr), defu(ugi);
           ugi[] = qpv.im;
           ugr[] = qpv.re;
-          savevtk(workdir + fileout + "_rslv_response.vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaviewDataNamec, order = ParaviewOrderc);
+          savevtk(workdir + fileout + "_rslv_response.vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaViewDataNamec, order = ParaViewOrderc);
         }
       }
     }
@@ -1632,11 +1632,11 @@ macro savefold(foldfileout, statsfile, meshfile, alpha, beta, saveflag, monitorf
         fespace XMhgpv(Thgpv, Pk);
         XMhgpv defu(ugr);
         ugr[] = qpv;
-        savevtk(workdir + foldfileout + "_fold_base.vtu", Thgpv, paraviewu(ugr), dataname = ParaviewDataName, order = ParaviewOrder);
+        savevtk(workdir + foldfileout + "_fold_base.vtu", Thgpv, paraviewu(ugr), dataname = ParaViewDataName, order = ParaViewOrder);
         ugr[] = qmpv;
-        savevtk(workdir + foldfileout + "_fold_dirmode.vtu", Thgpv, paraviewu(ugr), dataname = ParaviewDataName, order = ParaviewOrder);
+        savevtk(workdir + foldfileout + "_fold_dirmode.vtu", Thgpv, paraviewu(ugr), dataname = ParaViewDataName, order = ParaViewOrder);
         ugr[] = qmapv;
-        savevtk(workdir + foldfileout + "_fold_adjmode.vtu", Thgpv, paraviewu(ugr), dataname = ParaviewDataName, order = ParaviewOrder);
+        savevtk(workdir + foldfileout + "_fold_adjmode.vtu", Thgpv, paraviewu(ugr), dataname = ParaViewDataName, order = ParaViewOrder);
       }
     }
   }
@@ -1756,13 +1756,13 @@ macro savehopf(hopffileout, statsfile, meshfile, sym, omega, alpha, beta, savefl
         fespace XMhgpv(Thgpv, Pk);
         XMhgpv defu(ugr), defu(ugi);
         ugr[] = qpv;
-        savevtk(workdir + hopffileout + "_hopf_base.vtu", Thgpv, paraviewu(ugr), dataname = ParaviewDataName, order = ParaviewOrder);
+        savevtk(workdir + hopffileout + "_hopf_base.vtu", Thgpv, paraviewu(ugr), dataname = ParaViewDataName, order = ParaViewOrder);
         ugr[] = qmpv.re;
         ugi[] = qmpv.im;
-        savevtk(workdir + hopffileout + "_hopf_dirmode.vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaviewDataNamec, order = ParaviewOrderc);
+        savevtk(workdir + hopffileout + "_hopf_dirmode.vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaViewDataNamec, order = ParaViewOrderc);
         ugr[] = qmapv.re;
         ugi[] = qmapv.im;
-        savevtk(workdir + hopffileout + "_hopf_adjmode.vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaviewDataNamec, order = ParaviewOrderc);
+        savevtk(workdir + hopffileout + "_hopf_adjmode.vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaViewDataNamec, order = ParaViewOrderc);
       }
     }
   }
@@ -1840,7 +1840,7 @@ macro savetdls(tdlsfileout, statsfile, meshfile, basefile, ICfile, sym, time, sa
         XMhgpv defu(ugr), defu(ugi);
         ugr[] = qpv.re;
         ugi[] = qpv.im;
-        savevtk(workdir + tdlsfileout + "_tdls.vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaviewDataNamec, order = ParaviewOrderc);
+        savevtk(workdir + tdlsfileout + "_tdls.vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaViewDataNamec, order = ParaViewOrderc);
       }
     }
   }
@@ -1921,7 +1921,7 @@ macro savetdns(tdnsfileout, statsfile, meshfile, ICfile, time, saveflag, monitor
         fespace XMhgpv(Thgpv, Pk);
         XMhgpv defu(ugr);
         ugr[] = qpv;
-        savevtk(workdir + tdnsfileout + "_tdns.vtu", Thgpv, paraviewu(ugr), dataname = ParaviewDataName, order = ParaviewOrder);
+        savevtk(workdir + tdnsfileout + "_tdns.vtu", Thgpv, paraviewu(ugr), dataname = ParaViewDataName, order = ParaViewOrder);
       }
     }
   }
@@ -2058,19 +2058,19 @@ macro savehoho(hohofileout, statsfile, meshfile, sym1, sym2, omega1, omega2, alp
         fespace XMhgpv(Thgpv, Pk);
         XMhgpv defu(ugr), defu(ugi);
         ugr[] = qpv;
-        savevtk(workdir + hohofileout + "_hoho_base.vtu", Thgpv, paraviewu(ugr), dataname = ParaviewDataName, order = ParaviewOrder);
+        savevtk(workdir + hohofileout + "_hoho_base.vtu", Thgpv, paraviewu(ugr), dataname = ParaViewDataName, order = ParaViewOrder);
         ugr[] = q1mpv.re;
         ugi[] = q1mpv.im;
-        savevtk(workdir + hohofileout + "_hoho_dirmode1.vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaviewDataNamec, order = ParaviewOrderc);
+        savevtk(workdir + hohofileout + "_hoho_dirmode1.vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaViewDataNamec, order = ParaViewOrderc);
         ugr[] = q1mapv.re;
         ugi[] = q1mapv.im;
-        savevtk(workdir + hohofileout + "_hoho_adjmode1.vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaviewDataNamec, order = ParaviewOrderc);
+        savevtk(workdir + hohofileout + "_hoho_adjmode1.vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaViewDataNamec, order = ParaViewOrderc);
         ugr[] = q2mpv.re;
         ugi[] = q2mpv.im;
-        savevtk(workdir + hohofileout + "_hoho_dirmode2.vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaviewDataNamec, order = ParaviewOrderc);
+        savevtk(workdir + hohofileout + "_hoho_dirmode2.vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaViewDataNamec, order = ParaViewOrderc);
         ugr[] = q2mapv.re;
         ugi[] = q2mapv.im;
-        savevtk(workdir + hohofileout + "_hoho_adjmode2.vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaviewDataNamec, order = ParaviewOrderc);
+        savevtk(workdir + hohofileout + "_hoho_adjmode2.vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaViewDataNamec, order = ParaViewOrderc);
       }
     }
   }
@@ -2207,17 +2207,17 @@ macro savefoho(fohofileout, statsfile, meshfile, sym, omega, alpha1, alpha2, bet
         fespace XMhgpv(Thgpv, Pk);
         XMhgpv defu(ugr), defu(ugi);
         ugr[] = qpv;
-        savevtk(workdir + fohofileout + "_foho_base.vtu", Thgpv, paraviewu(ugr), dataname = ParaviewDataName, order = ParaviewOrder);
+        savevtk(workdir + fohofileout + "_foho_base.vtu", Thgpv, paraviewu(ugr), dataname = ParaViewDataName, order = ParaViewOrder);
         ugr[] = q1mpv.re;
         ugi[] = q1mpv.im;
-        savevtk(workdir + fohofileout + "_foho_dirmode1.vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaviewDataNamec, order = ParaviewOrderc);
+        savevtk(workdir + fohofileout + "_foho_dirmode1.vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaViewDataNamec, order = ParaViewOrderc);
         ugr[] = q1mapv.re;
         ugi[] = q1mapv.im;
-        savevtk(workdir + fohofileout + "_foho_adjmode1.vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaviewDataNamec, order = ParaviewOrderc);
+        savevtk(workdir + fohofileout + "_foho_adjmode1.vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaViewDataNamec, order = ParaViewOrderc);
         ugr[] = q2mpv;
-        savevtk(workdir + fohofileout + "_foho_dirmode2.vtu", Thgpv, paraviewu(ugr), dataname = ParaviewDataName, order = ParaviewOrder);
+        savevtk(workdir + fohofileout + "_foho_dirmode2.vtu", Thgpv, paraviewu(ugr), dataname = ParaViewDataName, order = ParaViewOrder);
         ugr[] = q2mapv;
-        savevtk(workdir + fohofileout + "_foho_adjmode2.vtu", Thgpv, paraviewu(ugr), dataname = ParaviewDataName, order = ParaviewOrder);
+        savevtk(workdir + fohofileout + "_foho_adjmode2.vtu", Thgpv, paraviewu(ugr), dataname = ParaViewDataName, order = ParaViewOrder);
       }
     }
   }
@@ -2323,12 +2323,12 @@ macro saveporb(porbfileout, statsfile, meshfile, sym, omega, Nh, saveflag, monit
         XMhgpv defu(ugr), defu(ugi);
         XMhgpv<complex> defu(ugc);
         ugr[] = qpv;
-        savevtk(workdir + porbfileout + "_porb_mean.vtu", Thgpv, paraviewu(ugr), dataname = ParaviewDataName, order = ParaviewOrder);
+        savevtk(workdir + porbfileout + "_porb_mean.vtu", Thgpv, paraviewu(ugr), dataname = ParaViewDataName, order = ParaViewOrder);
         for(int nh = 0; nh < Nh; nh++){
           ugc[] = qmpv(:, nh);
           ugr[] = ugc[].re;
           ugi[] = ugc[].im;
-          savevtk(workdir + porbfileout + "_porb_harm" + nh + ".vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaviewDataNamec, order = ParaviewOrderc);
+          savevtk(workdir + porbfileout + "_porb_harm" + nh + ".vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaViewDataNamec, order = ParaViewOrderc);
         }
       }
     }
@@ -2426,7 +2426,7 @@ macro savefloq(floqfileout, statsfile, basefile, meshfile, evecs, evals, omega, 
             ugc[] = qmpv(:, jj);
             ugr[] = ugc[].re;
             ugi[] = ugc[].im;
-            savevtk(workdir + floqfileout0 + "_floq_comp" + jj + ".vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaviewDataNamec, order = ParaviewOrderc);
+            savevtk(workdir + floqfileout0 + "_floq_comp" + jj + ".vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaViewDataNamec, order = ParaViewOrderc);
           }
         }
       }

--- a/macros_bifbox.idp
+++ b/macros_bifbox.idp
@@ -24,7 +24,6 @@ IFMACRO(!initf)
     macro adaptf(f) adaptu(f) // EOM
   ENDIFMACRO
   IFMACRO(!paraviewf)
-    macro paraviewf(f) adaptf(f) // EOM
     string[int] ParaViewNamesf = ParaViewNames;
   ENDIFMACRO
 ENDIFMACRO
@@ -32,6 +31,9 @@ ENDIFMACRO
 // If settings file does not define a ParaView output format
 IFMACRO(!paraviewu)
   macro paraviewu(u) adaptu(u) // EOM
+ENDIFMACRO
+IFMACRO(!paraviewf)
+  macro paraviewf(f) adaptf(f) // EOM
 ENDIFMACRO
 // If settings files does not define InitialConditions
 IFMACRO(!InitialConditions)

--- a/macros_bifbox.idp
+++ b/macros_bifbox.idp
@@ -14,7 +14,7 @@ int paraviewflag = getARGV("-pv", 0); // indicate whether solution is saved for 
 // paraviewflag == 1: save in ParaView format on current mesh
 // paraviewflag == 2, 3, ...: save in ParaView format on 2x, 3x, ... refined mesh using meshsplit
 
-// If settings file does not define a forcing
+// If settings file does not define forcing macros
 IFMACRO(!deff)
 IFMACRO(!initf)
   macro deff(f) defu(f) // EOM
@@ -23,14 +23,15 @@ IFMACRO(!initf)
   IFMACRO(!adaptf)
     macro adaptf(f) adaptu(f) // EOM
   ENDIFMACRO
+  IFMACRO(!paraviewf)
+    macro paraviewf(f) adaptf(f) // EOM
+    string[int] ParaViewNamesf = ParaViewNames;
+  ENDIFMACRO
 ENDIFMACRO
 ENDIFMACRO
 // If settings file does not define a ParaView output format
 IFMACRO(!paraviewu)
   macro paraviewu(u) adaptu(u) // EOM
-ENDIFMACRO
-IFMACRO(!paraviewf)
-  macro paraviewf(f) adaptf(f) // EOM
 ENDIFMACRO
 // If settings files does not define InitialConditions
 IFMACRO(!InitialConditions)

--- a/macros_bifbox.idp
+++ b/macros_bifbox.idp
@@ -317,6 +317,7 @@ macro domegaResidualHB(MqHB, J, ub, uh, sym0) {
         Rctemp = vdM(0, XMh, tgv = -10);
       }
       Rc += Rctemp;
+      IFMACRO(cubic)
       for (int k = 0; k < Nh; k++) {
         if (k != nh-j-1 && k < Nh+nh-j) {
           um2[] = 0.5*uh(:, k);
@@ -337,6 +338,7 @@ macro domegaResidualHB(MqHB, J, ub, uh, sym0) {
           Rc += Rctemp;
         }
       }
+      ENDIFMACRO
     }
     Rc *= 1i*(1+nh);
     ChangeNumbering([J, J], [Rc.re, Rc.im], Rtemp);
@@ -972,6 +974,7 @@ macro MassHBcplx(MHB, J, ub, uh, sym0, sym1) {
     ik.im = (sym1);
     Mat<complex>[int, int] MHBtemp(1+2*Nh, 1+2*Nh);
     matrix<complex> Cmat, An3i, An2r = vM(XMh, XMh, tgv = -20);
+    IFMACRO(cubic)
     ik3.im = (sym1);
     for (int j = 0; j < Nh; j++){
       um[] = uh(:, j);
@@ -981,6 +984,7 @@ macro MassHBcplx(MHB, J, ub, uh, sym0, sym1) {
       Cmat = vddM(XMh, XMh, tgv = -20);
       An2r += Cmat;
     }
+    ENDIFMACRO
     constructor(MHBtemp(0, 0), J, An2r);
     for (int j = 0; j < Nh; j++){
       um[] = uh(:, j);
@@ -991,6 +995,7 @@ macro MassHBcplx(MHB, J, ub, uh, sym0, sym1) {
       ik.im *= -1.0;
       ik2.im = (1+j)*(sym0) + (sym1);
       An2r = vdM(XMh, XMh, tgv = -20);
+      IFMACRO(cubic)
       for (int k = 0; k < Nh; k++){
         if (k < Nh-j-1) {
           um[] = uh(:, 1+j+k);
@@ -1025,6 +1030,7 @@ macro MassHBcplx(MHB, J, ub, uh, sym0, sym1) {
           An2r += Cmat;
         }
       }
+      ENDIFMACRO
       constructor(MHBtemp(0, 1+2*j), J, An2r);
       constructor(MHBtemp(0, 2+2*j), J, An3i);
     }
@@ -1039,6 +1045,7 @@ macro MassHBcplx(MHB, J, ub, uh, sym0, sym1) {
       ik.im *= -1.0;
       ik2.im = (sym1);
       An3i = vdM(XMh, XMh, tgv = -20);
+      IFMACRO(cubic)
       ik3.im = (sym1);
       for (int j = 0; j < Nh; j++) {
         if (j != nh) {
@@ -1059,6 +1066,7 @@ macro MassHBcplx(MHB, J, ub, uh, sym0, sym1) {
           An3i += Cmat;
         }
       }
+      ENDIFMACRO
       constructor(MHBtemp(1+2*nh, 0), J, An2r);
       constructor(MHBtemp(2+2*nh, 0), J, An3i);
       for (int j = 0; j < Nh; j++) {
@@ -1107,6 +1115,7 @@ macro MassHBcplx(MHB, J, ub, uh, sym0, sym1) {
           ik2.im = (1+j)*(sym0) + (sym1);
           An2i = vdM(XMh, XMh, tgv = -20);
         }
+        IFMACRO(cubic)
         for (int k = 0; k < Nh; k++) {
           if (k != nh-j-1 && k < Nh+nh-j) {
             sym = (1+nh)*(sym0) + (sym1);
@@ -1183,6 +1192,7 @@ macro MassHBcplx(MHB, J, ub, uh, sym0, sym1) {
             An2i += Cmat;
           }
         }
+        ENDIFMACRO
         constructor(MHBtemp(1+2*nh, 1+2*j), J, An2r);
         constructor(MHBtemp(1+2*nh, 2+2*j), J, An3r);
         constructor(MHBtemp(2+2*nh, 1+2*j), J, An2i);

--- a/macros_bifbox.idp
+++ b/macros_bifbox.idp
@@ -13,6 +13,18 @@ int paraviewflag = getARGV("-pv", 0); // indicate whether solution is saved for 
 // paraviewflag <= 0: don't save data in ParaView format (only in FF format)
 // paraviewflag == 1: save in ParaView format on current mesh
 // paraviewflag == 2, 3, ...: save in ParaView format on 2x, 3x, ... refined mesh using meshsplit
+
+// If settings file does not define a forcing
+IFMACRO(!deff)
+IFMACRO(!initf)
+  macro deff(f) defu(f) // EOM
+  macro initf(i) initu(i) // EOM
+  func Pkf = Pk;
+  IFMACRO(!adaptf)
+    macro adaptf(f) adaptu(f) // EOM
+  ENDIFMACRO
+ENDIFMACRO
+ENDIFMACRO
 // If settings file does not define a ParaView output format
 IFMACRO(!paraviewu)
   macro paraviewu(u) adaptu(u) // EOM
@@ -42,7 +54,7 @@ ParaViewOrderf = 1;
 int[int] ParaViewOrderc  = [ParaViewOrder,  ParaViewOrder];
 int[int] ParaViewOrderfc = [ParaViewOrderf, ParaViewOrderf];
 // Convert ParaViewNames into the strings: ParaViewDataName, ParaViewDataNamec
-string ParaViewDataName="", ParaViewDataNamec="";
+string ParaViewDataName, ParaViewDataNamec;
 for (int i=0; i<ParaViewNames.n; i++) {
     if (i) { ParaViewDataName = ParaViewDataName + " "; ParaViewDataNamec = ParaViewDataNamec + " "; }
     ParaViewDataName  = ParaViewDataName + ParaViewNames[i];
@@ -51,7 +63,7 @@ for (int i=0; i<ParaViewNames.n; i++) {
 for (int i=0; i<ParaViewNames.n; i++)
     ParaViewDataNamec = ParaViewDataNamec + " " + ParaViewNames[i] + "_i";
 // Convert ParaViewNamesf into the strings: ParaViewDataNamef, ParaViewDataNamefc
-string ParaViewDataNamef="", ParaViewDataNamefc="";
+string ParaViewDataNamef, ParaViewDataNamefc;
 for (int i=0; i<ParaViewNamesf.n; i++) {
     if (i) { ParaViewDataNamef = ParaViewDataNamef + " "; ParaViewDataNamefc = ParaViewDataNamefc + " "; }
     ParaViewDataNamef  = ParaViewDataNamef + ParaViewNamesf[i];

--- a/meshcompute.md
+++ b/meshcompute.md
@@ -61,7 +61,7 @@ for (ii = 0; ii < filecount; ii++) {
   else if ( fileexts[ii] == "hopf" || fileexts[ii] == "porb" ) nuvec += 5;
   else if ( fileexts[ii] == "foho" ) nuvec += 7;
   else if ( fileexts[ii] == "hoho" ) nuvec += 9;
-  else if ( fileexts[ii] == "rslv" ) {nuvec += 3; nfvec += 2;}
+  else if ( fileexts[ii] == "rslv" ) {nuvec += 2; nfvec += 2;}
 }
 string meshroot, meshext = parsefilename(meshin, meshroot);
 parsefilename(meshout, meshout); // trim extension from output mesh, if given

--- a/printparaview.md
+++ b/printparaview.md
@@ -17,7 +17,7 @@ include "macros_bifbox.idp"
 string meshin = getARGV("-mi", ""); // input meshfile
 string filein = getARGV("-fi", "");
 string fileout = getARGV("-fo", filein);
-paraviewflag = getARGV("-pv", 1); // indicate whether solution is saved for Paraview
+paraviewflag = getARGV("-pv", 1); // indicate whether solution is saved for ParaView
 
 assert(filein.rfind(".") > 0); // assert that filein includes extension
 string fileroot, fileext = parsefilename(filein, fileroot);
@@ -46,7 +46,7 @@ if (mpirank==0){
     fespace XMhgpv(Thgpv, Pk);
     XMhgpv defu(ugr);
     ugr[] = qpv;
-    savevtk(workdir + fileout + "_base.vtu", Thgpv, paraviewu(ugr), dataname = ParaviewDataName, order = ParaviewOrder);
+    savevtk(workdir + fileout + "_base.vtu", Thgpv, paraviewu(ugr), dataname = ParaViewDataName, order = ParaViewOrder);
   }
   else if (fileext == "mode"){
     XMhg<complex> defu(umg);
@@ -67,7 +67,7 @@ if (mpirank==0){
     XMhgpv defu(ugr), defu(ugi);
     ugr[] = qpv.re;
     ugi[] = qpv.im;
-    savevtk(workdir + fileout + "_mode.vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaviewDataNamec, order = ParaviewOrderc);
+    savevtk(workdir + fileout + "_mode.vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaViewDataNamec, order = ParaViewOrderc);
   }
   else if (fileext == "resp"){
     XMhg<complex> defu(umg);
@@ -88,7 +88,7 @@ if (mpirank==0){
     XMhgpv defu(ugr), defu(ugi);
     ugr[] = qpv.re;
     ugi[] = qpv.im;
-    savevtk(workdir + fileout + "_resp.vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaviewDataNamec, order = ParaviewOrderc);
+    savevtk(workdir + fileout + "_resp.vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaViewDataNamec, order = ParaViewOrderc);
   }
   else if (fileext == "rslv"){
     Xhg<complex> deff(fmg);
@@ -115,12 +115,12 @@ if (mpirank==0){
     Xhgpv deff(fgr), deff(fgi);
     fgr[] = fpv.re;
     fgi[] = fpv.im;
-    savevtk(workdir + fileout + "_rslv_forcing.vtu", Thgpv, paraviewf(fgr), paraviewf(fgi), dataname = ParaviewDataNamefc, order = ParaviewOrderfc);
+    savevtk(workdir + fileout + "_rslv_forcing.vtu", Thgpv, paraviewf(fgr), paraviewf(fgi), dataname = ParaViewDataNamefc, order = ParaViewOrderfc);
     fespace XMhgpv(Thgpv, Pk);
     XMhgpv defu(ugr), defu(ugi);
     ugi[] = qpv.im;
     ugr[] = qpv.re;
-    savevtk(workdir + fileout + "_rslv_response.vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaviewDataNamec, order = ParaviewOrderc);
+    savevtk(workdir + fileout + "_rslv_response.vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaViewDataNamec, order = ParaViewOrderc);
   }
   else if (fileext == "fold"){
     XMhg defu(ubg), defu(umg), defu(umag);
@@ -147,11 +147,11 @@ if (mpirank==0){
     fespace XMhgpv(Thgpv, Pk);
     XMhgpv defu(ugr);
     ugr[] = qpv;
-    savevtk(workdir + fileout + "_fold_base.vtu", Thgpv, paraviewu(ugr), dataname = ParaviewDataName, order = ParaviewOrder);
+    savevtk(workdir + fileout + "_fold_base.vtu", Thgpv, paraviewu(ugr), dataname = ParaViewDataName, order = ParaViewOrder);
     ugr[] = qmpv;
-    savevtk(workdir + fileout + "_fold_dirmode.vtu", Thgpv, paraviewu(ugr), dataname = ParaviewDataName, order = ParaviewOrder);
+    savevtk(workdir + fileout + "_fold_dirmode.vtu", Thgpv, paraviewu(ugr), dataname = ParaViewDataName, order = ParaViewOrder);
     ugr[] = qmapv;
-    savevtk(workdir + fileout + "_fold_adjmode.vtu", Thgpv, paraviewu(ugr), dataname = ParaviewDataName, order = ParaviewOrder);
+    savevtk(workdir + fileout + "_fold_adjmode.vtu", Thgpv, paraviewu(ugr), dataname = ParaViewDataName, order = ParaViewOrder);
   }
   else if (fileext == "hopf"){
     XMhg defu(ubg);
@@ -181,13 +181,13 @@ if (mpirank==0){
     fespace XMhgpv(Thgpv, Pk);
     XMhgpv defu(ugr), defu(ugi);
     ugr[] = qpv;
-    savevtk(workdir + fileout + "_hopf_base.vtu", Thgpv, paraviewu(ugr), dataname = ParaviewDataName, order = ParaviewOrder);
+    savevtk(workdir + fileout + "_hopf_base.vtu", Thgpv, paraviewu(ugr), dataname = ParaViewDataName, order = ParaViewOrder);
     ugr[] = qmpv.re;
     ugi[] = qmpv.im;
-    savevtk(workdir + fileout + "_hopf_dirmode.vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaviewDataNamec, order = ParaviewOrderc);
+    savevtk(workdir + fileout + "_hopf_dirmode.vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaViewDataNamec, order = ParaViewOrderc);
     ugr[] = qmapv.re;
     ugi[] = qmapv.im;
-    savevtk(workdir + fileout + "_hopf_adjmode.vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaviewDataNamec, order = ParaviewOrderc);
+    savevtk(workdir + fileout + "_hopf_adjmode.vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaViewDataNamec, order = ParaViewOrderc);
   }
   else if (fileext == "tdns"){
     XMhg defu(ubg);
@@ -207,7 +207,7 @@ if (mpirank==0){
     fespace XMhgpv(Thgpv, Pk);
     XMhgpv defu(ugr);
     ugr[] = qpv;
-    savevtk(workdir + fileout + "_tdns.vtu", Thgpv, paraviewu(ugr), dataname = ParaviewDataName, order = ParaviewOrder);
+    savevtk(workdir + fileout + "_tdns.vtu", Thgpv, paraviewu(ugr), dataname = ParaViewDataName, order = ParaViewOrder);
   }
   else if (fileext == "tdls"){
     XMhg<complex> defu(umg);
@@ -229,7 +229,7 @@ if (mpirank==0){
     XMhgpv defu(ugr), defu(ugi);
     ugr[] = qpv.re;
     ugi[] = qpv.im;
-    savevtk(workdir + fileout + "_tdls.vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaviewDataNamec, order = ParaviewOrderc);
+    savevtk(workdir + fileout + "_tdls.vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaViewDataNamec, order = ParaViewOrderc);
   }
   else if (fileext == "hoho"){
     XMhg defu(ubg);
@@ -266,19 +266,19 @@ if (mpirank==0){
     fespace XMhgpv(Thgpv, Pk);
     XMhgpv defu(ugr), defu(ugi);
     ugr[] = qpv;
-    savevtk(workdir + fileout + "_hoho_base.vtu", Thgpv, paraviewu(ugr), dataname = ParaviewDataName, order = ParaviewOrder);
+    savevtk(workdir + fileout + "_hoho_base.vtu", Thgpv, paraviewu(ugr), dataname = ParaViewDataName, order = ParaViewOrder);
     ugr[] = q1mpv.re;
     ugi[] = q1mpv.im;
-    savevtk(workdir + fileout + "_hoho_dirmode1.vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaviewDataNamec, order = ParaviewOrderc);
+    savevtk(workdir + fileout + "_hoho_dirmode1.vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaViewDataNamec, order = ParaViewOrderc);
     ugr[] = q1mapv.re;
     ugi[] = q1mapv.im;
-    savevtk(workdir + fileout + "_hoho_adjmode1.vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaviewDataNamec, order = ParaviewOrderc);
+    savevtk(workdir + fileout + "_hoho_adjmode1.vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaViewDataNamec, order = ParaViewOrderc);
     ugr[] = q2mpv.re;
     ugi[] = q2mpv.im;
-    savevtk(workdir + fileout + "_hoho_dirmode2.vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaviewDataNamec, order = ParaviewOrderc);
+    savevtk(workdir + fileout + "_hoho_dirmode2.vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaViewDataNamec, order = ParaViewOrderc);
     ugr[] = q2mapv.re;
     ugi[] = q2mapv.im;
-    savevtk(workdir + fileout + "_hoho_adjmode2.vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaviewDataNamec, order = ParaviewOrderc);
+    savevtk(workdir + fileout + "_hoho_adjmode2.vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaViewDataNamec, order = ParaViewOrderc);
   }
   else if (fileext == "foho"){
     XMhg defu(ubg), defu(u2mg), defu(u2mag);
@@ -318,17 +318,17 @@ if (mpirank==0){
     fespace XMhgpv(Thgpv, Pk);
     XMhgpv defu(ugr), defu(ugi);
     ugr[] = qpv;
-    savevtk(workdir + fileout + "_foho_base.vtu", Thgpv, paraviewu(ugr), dataname = ParaviewDataName, order = ParaviewOrder);
+    savevtk(workdir + fileout + "_foho_base.vtu", Thgpv, paraviewu(ugr), dataname = ParaViewDataName, order = ParaViewOrder);
     ugr[] = q1mpv.re;
     ugi[] = q1mpv.im;
-    savevtk(workdir + fileout + "_foho_dirmode1.vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaviewDataNamec, order = ParaviewOrderc);
+    savevtk(workdir + fileout + "_foho_dirmode1.vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaViewDataNamec, order = ParaViewOrderc);
     ugr[] = q1mapv.re;
     ugi[] = q1mapv.im;
-    savevtk(workdir + fileout + "_foho_adjmode1.vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaviewDataNamec, order = ParaviewOrderc);
+    savevtk(workdir + fileout + "_foho_adjmode1.vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaViewDataNamec, order = ParaViewOrderc);
     ugr[] = q2mpv;
-    savevtk(workdir + fileout + "_foho_dirmode2.vtu", Thgpv, paraviewu(ugr), dataname = ParaviewDataName, order = ParaviewOrder);
+    savevtk(workdir + fileout + "_foho_dirmode2.vtu", Thgpv, paraviewu(ugr), dataname = ParaViewDataName, order = ParaViewOrder);
     ugr[] = q2mapv;
-    savevtk(workdir + fileout + "_foho_adjmode2.vtu", Thgpv, paraviewu(ugr), dataname = ParaviewDataName, order = ParaviewOrder);
+    savevtk(workdir + fileout + "_foho_adjmode2.vtu", Thgpv, paraviewu(ugr), dataname = ParaViewDataName, order = ParaViewOrder);
   }
   else if (fileext == "porb"){
     XMhg defu(ubg);
@@ -359,12 +359,12 @@ if (mpirank==0){
     XMhgpv defu(ugr), defu(ugi);
     XMhgpv<complex> defu(ugc);
     ugr[] = qpv;
-    savevtk(workdir + fileout + "_porb_mean.vtu", Thgpv, paraviewu(ugr), dataname = ParaviewDataName, order = ParaviewOrder);
+    savevtk(workdir + fileout + "_porb_mean.vtu", Thgpv, paraviewu(ugr), dataname = ParaViewDataName, order = ParaViewOrder);
     for(int harm = 0; harm < Nh; harm++){
       ugc[] = qmpv(:, harm);
       ugr[] = ugc[].re;
       ugi[] = ugc[].im;
-      savevtk(workdir + fileout + "_porb_harm" + harm + ".vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaviewDataNamec, order = ParaviewOrderc);
+      savevtk(workdir + fileout + "_porb_harm" + harm + ".vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaViewDataNamec, order = ParaViewOrderc);
     }
   }
   else if (fileext == "floq"){
@@ -402,7 +402,7 @@ if (mpirank==0){
       ugc[] = qmpv(:, jj);
       ugr[] = ugc[].re;
       ugi[] = ugc[].im;
-      savevtk(workdir + fileout + "_floq_comp" + jj + ".vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaviewDataNamec, order = ParaviewOrderc);
+      savevtk(workdir + fileout + "_floq_comp" + jj + ".vtu", Thgpv, paraviewu(ugr), paraviewu(ugi), dataname = ParaViewDataNamec, order = ParaViewOrderc);
     }
   }
 }


### PR DESCRIPTION
1. Streamlines ParaView arrays in settings file so that only `string[int] ParaViewNames` (and in most cases `string[int] ParaViewNamesf`) are required. The use no longer needs to manually specify different arrays for real and complex values, and a default order of 1 is assumed.
2. Changes behavior so that `macros_bifbox.idp` autopopulates forcing macros for forced response/resolvent analysis if are not specified in `settings.idp`.